### PR TITLE
v.1.2.0: Big casts refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 MODULES = uint128
 EXTENSION = uint128
 DATA = uint128--1.0.0.sql uint128--1.0.0--1.0.1.sql uint128--1.0.1--1.1.0.sql uint128--1.1.0.sql \
- 	uint128--1.1.0--1.1.1.sql uint128--1.1.1.sql
+ 	uint128--1.1.0--1.1.1.sql uint128--1.1.1.sql \
+ 	uint128--1.1.1--1.2.0.sql uint128--1.2.0.sql
 REGRESS = create_ext test_uint1 test_uint2 test_uint4 test_uint8 test_uint16 test_int1 test_int16 \
 	test_1.1.0_int16 test_1.1.0_uint2 test_1.1.0_uint4 test_1.1.0_uint8 test_1.1.0_uint16 \
 	test_1.1.1_int1 test_1.1.1_int16 test_1.1.1_uint1 test_1.1.1_uint2 test_1.1.1_uint4 test_1.1.1_uint8 test_1.1.1_uint16

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ OBJS = magic.o uint128.o uint64.o uint32.o uint16.o uint8.o int128.o int8.o uint
 	bitwise/uint8.o bitwise/uint16.o bitwise/uint32.o bitwise/uint64.o bitwise/uint128.o \
 	casts/uint8.o casts/uint16.o casts/uint32.o casts/uint64.o casts/uint128.o \
 	casts/int8.o casts/int16.o casts/int32.o casts/int64.o casts/int128.o \
+	casts/float4.o casts/float8.o \
+	casts/json.o casts/jsonb.o casts/numeric.o \
 	casts/json_utils.o \
 	agg/uint8.o agg/uint16.o agg/uint32.o agg/uint64.o agg/uint128.o agg/int8.o agg/int128.o \
 	series/uint8.o series/uint16.o series/uint32.o series/uint64.o series/uint128.o series/int8.o series/int128.o \

--- a/_codegen/sql/sqlgen_v1.0.0.php
+++ b/_codegen/sql/sqlgen_v1.0.0.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/sql_gen_core.php';
 require_once __DIR__ . '/sqlgen_v1.0.0_types.php';
 
+$VERSION_NUM = 1000;
+
 $types = getV1_0_0_Types();
 
 $buf = '';
@@ -16,7 +18,7 @@ foreach ($types as $type) {
 $buf .= "\n";
 
 foreach ($types as $type) {
-    $buf .= $type->toSQL(EXT_NAME) . "\n";
+    $buf .= $type->toSQL($VERSION_NUM, EXT_NAME) . "\n";
 }
 
 $buf .= "\n\n-- Cross types ops\n";
@@ -37,7 +39,7 @@ $CROSS_TYPES = buildCrossTypes(V1_0_0_UINT_TYPES, V1_0_0_INT_TYPES);
 //];
 
 foreach (genSQLForCrossTypes($types, $CROSS_TYPES) as $typConfig) {
-    $buf .= $typConfig->toSQL(EXT_NAME) . "\n\n";
+    $buf .= $typConfig->toSQL($VERSION_NUM, EXT_NAME) . "\n\n";
 }
 
 file_put_contents("uint128--1.0.0.sql", $buf);

--- a/_codegen/sql/sqlgen_v1.1.0.php
+++ b/_codegen/sql/sqlgen_v1.1.0.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/sql_gen_core.php';
 require_once __DIR__ . '/sqlgen_v1.0.0_types.php';
 require_once __DIR__ . '/sqlgen_v1.1.0_types.php';
 
+$VERSION_NUM = 1100;
+
 $types = getV1_1_0_Types();
 $buf = '';
 
@@ -14,7 +16,7 @@ foreach ($types as $type) {
 }
 
 foreach ($types as $type) {
-    $buf .= $type->toSQL(EXT_NAME) . "\n";;
+    $buf .= $type->toSQL($VERSION_NUM, EXT_NAME) . "\n";;
 }
 
 $buf .= "\n\n-- Cross types ops\n";
@@ -25,7 +27,7 @@ $CROSS_TYPES = buildCrossTypes(V1_1_0_UINT_TYPES, V1_1_0_INT_TYPES);
 $crossTests = [];
 
 foreach (genSQLForCrossTypes($types, $CROSS_TYPES) as $typConfig) {
-    $buf .= $typConfig->toSQL(EXT_NAME) . "\n\n";
+    $buf .= $typConfig->toSQL($VERSION_NUM, EXT_NAME) . "\n\n";
 
     $crossTests[$typConfig->type->pgName] = $typConfig->toSQLTests();
 }
@@ -74,7 +76,7 @@ function buildV1_0_0_CrossTypesSQL(): Generator
 $crossTestsWithOldTypes = [];
 
 foreach (buildV1_0_0_CrossTypesSQL() as $typConfig) {
-    $buf .= $typConfig->toSQL(EXT_NAME) . "\n\n";
+    $buf .= $typConfig->toSQL($VERSION_NUM, EXT_NAME) . "\n\n";
 
     $crossTestsWithOldTypes[$typConfig->type->pgName] = $typConfig->toSQLTests();
 }

--- a/_codegen/sql/sqlgen_v1.1.1.php
+++ b/_codegen/sql/sqlgen_v1.1.1.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 require_once __DIR__ . '/sql_gen_core.php';
 require_once __DIR__ . '/sqlgen_v1.1.1_types.php';
 
+$VERSION_NUM = 1110;
+
 $types = getV1_1_1_Types();
 $buf = '';
 
@@ -32,7 +34,7 @@ EOF;
 }
 
 foreach ($types as $type) {
-    $buf .= $type->toSQL(EXT_NAME) . "\n";
+    $buf .= $type->toSQL($VERSION_NUM, EXT_NAME) . "\n";
 
     // Fast casts to numeric
     if (in_array($type->type, [INT8, UINT8, UINT16, UINT32], true)) {

--- a/_codegen/sql/sqlgen_v1.2.0.php
+++ b/_codegen/sql/sqlgen_v1.2.0.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/sql_gen_core.php';
+require_once __DIR__ . '/sqlgen_v1.2.0_types.php';
+
+$VERSION_NUM = 1200;
+
+$types = getV1_2_0_Types();
+$buf = '';
+
+$buf .= "-- Cleanup old casts \n\n";
+$buf .= <<<SQL
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT
+            p.oid,
+            p.castfunc,
+            p.castsource,
+            p.casttarget
+        FROM
+            pg_catalog.pg_extension AS e
+        JOIN pg_catalog.pg_depend AS d ON d.refobjid = e.oid
+        JOIN pg_catalog.pg_cast AS p ON p.oid = d.objid
+        JOIN pg_type AS t ON t.oid = p.casttarget AND t.typtype NOT IN ('r', 'm')
+        JOIN pg_type AS t2 ON t2.oid = p.castsource AND t2.typtype NOT IN ('r', 'm')
+        WHERE
+            d.deptype = 'e'
+            AND e.extname = 'uint128'
+            AND (p.castsource, p.casttarget) NOT IN (
+                ('int16'::regtype, 'numeric'::regtype),
+                ('numeric'::regtype, 'int16'::regtype),
+                ('uint16'::regtype, 'numeric'::regtype),
+                ('numeric'::regtype, 'uint16'::regtype),
+                ('uint8'::regtype, 'numeric'::regtype),
+                ('numeric'::regtype, 'uint8'::regtype)
+            )
+        ORDER BY 3, 4
+    LOOP
+        RAISE NOTICE 'Dropping cast (% -> %)', r.castsource::regtype, r.casttarget::regtype;
+        EXECUTE format('DROP CAST (%I AS %I)', r.castsource::regtype, r.casttarget::regtype);
+
+        IF r.castfunc IS NOT NULL AND r.castfunc > 0 THEN
+            RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
+            EXECUTE format('DROP FUNCTION %I', r.castfunc::regprocedure);
+        END IF;
+    END LOOP;
+END $$;
+SQL;
+$buf .= "\n\n";
+
+foreach ($types as $type) {
+    $buf .= "-- Type {$type->type->pgName} block\n\n";
+
+    $buf .= "-- Cast functions {$type->type->pgName} block\n\n";
+
+    foreach ($type->casts as $cast) {
+        $buf .= $type->toSQLCastFunctions($VERSION_NUM, $cast) . "\n";
+    }
+}
+
+foreach ($types as $type) {
+    $buf .= "-- Casts {$type->type->pgName} block\n\n";
+
+    foreach ($type->casts as $cast) {
+        $buf .= $type->toSQLCast($VERSION_NUM, $cast);
+    }
+
+    foreach ($type->inOutCasts as $cast) {
+        $buf .= $type->toSQLInOutCast($VERSION_NUM, $cast);
+    }
+
+    $buf .= "\n";
+}
+
+$fileName = "uint128--1.1.1--1.2.0.sql";
+file_put_contents($fileName, $buf);
+echo "$fileName successfully generated\n";
+
+@mkdir("sql");
+@mkdir("expected");

--- a/_codegen/sql/sqlgen_v1.2.0.php
+++ b/_codegen/sql/sqlgen_v1.2.0.php
@@ -10,6 +10,16 @@ $VERSION_NUM = 1200;
 $types = getV1_2_0_Types();
 $buf = '';
 
+foreach ($types as $type) {
+    $buf .= "-- Type {$type->type->pgName} block\n\n";
+
+    $buf .= "-- Cast functions {$type->type->pgName} block\n\n";
+
+    foreach ($type->casts as $cast) {
+        $buf .= $type->toSQLCastFunctions($VERSION_NUM, $cast, true) . "\n";
+    }
+}
+
 $buf .= "-- Cleanup old casts \n\n";
 $buf .= <<<SQL
 DO $$
@@ -31,37 +41,19 @@ BEGIN
         WHERE
             d.deptype = 'e'
             AND e.extname = 'uint128'
-            AND (p.castsource, p.casttarget) NOT IN (
-                ('int16'::regtype, 'numeric'::regtype),
-                ('numeric'::regtype, 'int16'::regtype),
-                ('uint16'::regtype, 'numeric'::regtype),
-                ('numeric'::regtype, 'uint16'::regtype),
-                ('uint8'::regtype, 'numeric'::regtype),
-                ('numeric'::regtype, 'uint8'::regtype)
-            )
         ORDER BY 3, 4
     LOOP
         RAISE NOTICE 'Dropping cast (% -> %)', r.castsource::regtype, r.casttarget::regtype;
-        EXECUTE format('DROP CAST (%I AS %I)', r.castsource::regtype, r.casttarget::regtype);
+        EXECUTE format('DROP CAST (%s AS %s)', r.castsource::regtype, r.casttarget::regtype);
 
-        IF r.castfunc IS NOT NULL AND r.castfunc > 0 THEN
-            RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
-            EXECUTE format('DROP FUNCTION %I', r.castfunc::regprocedure);
-        END IF;
+--         IF r.castfunc IS NOT NULL AND r.castfunc > 0 THEN
+--             RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
+--             EXECUTE format('DROP FUNCTION %s', r.castfunc::regprocedure);
+--         END IF;
     END LOOP;
 END $$;
 SQL;
 $buf .= "\n\n";
-
-foreach ($types as $type) {
-    $buf .= "-- Type {$type->type->pgName} block\n\n";
-
-    $buf .= "-- Cast functions {$type->type->pgName} block\n\n";
-
-    foreach ($type->casts as $cast) {
-        $buf .= $type->toSQLCastFunctions($VERSION_NUM, $cast) . "\n";
-    }
-}
 
 foreach ($types as $type) {
     $buf .= "-- Casts {$type->type->pgName} block\n\n";
@@ -77,7 +69,114 @@ foreach ($types as $type) {
     $buf .= "\n";
 }
 
+$buf .= "-- Cleanup old cast functions\n\n";
+$buf .= <<<SQL
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT
+            p.oid,
+            p.castfunc,
+            p.castsource,
+            p.casttarget
+        FROM
+            pg_catalog.pg_extension AS e
+        JOIN pg_catalog.pg_depend AS d ON d.refobjid = e.oid
+        JOIN pg_catalog.pg_cast AS p ON p.oid = d.objid
+        JOIN pg_type AS t ON t.oid = p.casttarget AND t.typtype NOT IN ('r', 'm')
+        JOIN pg_type AS t2 ON t2.oid = p.castsource AND t2.typtype NOT IN ('r', 'm')
+        WHERE
+            d.deptype = 'e'
+            AND e.extname = 'uint128'
+        ORDER BY 3, 4
+    LOOP
+--         RAISE NOTICE 'Dropping cast (% -> %)', r.castsource::regtype, r.casttarget::regtype;
+--         EXECUTE format('DROP CAST (%s AS %s)', r.castsource::regtype, r.casttarget::regtype);
+
+        IF r.castfunc IS NOT NULL AND r.castfunc > 0 AND r.castfunc::regprocedure::text LIKE '%_to_%' THEN
+            RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
+            EXECUTE format('DROP FUNCTION %s', r.castfunc::regprocedure);
+        END IF;
+    END LOOP;
+END $$;
+SQL;
+$buf .= "\n\n";
+
 $fileName = "uint128--1.1.1--1.2.0.sql";
+file_put_contents($fileName, $buf);
+echo "$fileName successfully generated\n";
+
+// Full version dump below
+
+$buf = '';
+
+foreach ($types as $type) {
+    // Skip builtin types, this block is only for the extension types
+    if ($type->type->builtIn) continue;
+
+    $buf .= $type->toSQLTypeDef($VERSION_NUM) . "\n";
+
+    foreach ($type->ops as $op) {
+        $buf .= genSQLOperatorFunc($op->op, $type->type, $type->type) . "\n";
+    }
+    foreach ($type->ops as $op) {
+        $buf .= genSQLOperator($op->op, $type->type, $type->type) . "\n";
+    }
+
+    $buf .= $type->toSQLOperatorFamily($VERSION_NUM) . "\n";
+
+    $buf .= "\n";
+}
+
+// Generate cross type operators
+foreach ($types as $type) {
+    $buf .= "\n-- Cross-type operators for {$type->type->pgName}\n\n";
+
+    foreach ($type->ops as $op) {
+        foreach ($op->types as $opType) {
+            $buf .= genSQLOperatorFunc($op->op, $type->type, $opType) . "\n";
+        }
+    }
+
+    foreach ($type->ops as $op) {
+        foreach ($op->types as $opType) {
+            $buf .= genSQLOperator($op->op, $type->type, $opType) . "\n";
+        }
+    }
+}
+
+foreach ($types as $type) {
+    // Skip builtin types, this block is only for the extension types
+    if ($type->type->builtIn) continue;
+
+    $buf .= $type->toSQLAggOps($VERSION_NUM) . "\n";
+    $buf .= $type->toSQLRanges($VERSION_NUM) . "\n";
+    $buf .= $type->toSQLGenSeries($VERSION_NUM) . "\n";
+}
+
+foreach ($types as $type) {
+    $buf .= "-- Cast functions for {$type->type->pgName}\n\n";
+
+    foreach ($type->casts as $cast) {
+        $buf .= $type->toSQLCastFunctions($VERSION_NUM, $cast);
+    }
+
+    $buf .= "-- Casts for {$type->type->pgName}\n\n";
+
+    foreach ($type->casts as $cast) {
+        $buf .= $type->toSQLCast($VERSION_NUM, $cast);
+    }
+
+    foreach ($type->inOutCasts as $cast) {
+        $buf .= $type->toSQLInOutCast($VERSION_NUM, $cast);
+    }
+
+    $buf .= "\n";
+}
+
+$fileName = "uint128--1.2.0.sql";
 file_put_contents($fileName, $buf);
 echo "$fileName successfully generated\n";
 

--- a/_codegen/sql/sqlgen_v1.2.0_types.php
+++ b/_codegen/sql/sqlgen_v1.2.0_types.php
@@ -23,53 +23,88 @@ function typesExcept(array $types, Type $except): array
     return $crossTypes;
 }
 
+/**
+ * @return array
+ */
+function makeDefaultTypeOps(Type $type): array
+{
+    if ($type->builtIn) {
+        $defaultUintOpsTypes = typesExcept([
+            ...CUSTOM_INT_TYPES,
+            ...UINT_TYPES,
+        ], $type);
+    } else {
+        $defaultUintOpsTypes = typesExcept([
+            ...INT_TYPES,
+            ...UINT_TYPES,
+        ], $type);
+    }
+
+    return [
+        new TypeOpConfig(Op::Eq, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Ne, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Gt, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Lt, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Ge, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Le, types: $defaultUintOpsTypes, inverseTypes: false),
+
+        new TypeOpConfig(Op::Add, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Sub, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Mul, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Div, types: $defaultUintOpsTypes, inverseTypes: false),
+        new TypeOpConfig(Op::Mod, types: $defaultUintOpsTypes, inverseTypes: false),
+
+        new TypeOpConfig(Op::Xor),
+        new TypeOpConfig(Op::And),
+        new TypeOpConfig(Op::Or),
+        new TypeOpConfig(Op::Not),
+        new TypeOpConfig(Op::Shl),
+        new TypeOpConfig(Op::Shr),
+    ];
+}
+
 /** @var array<TypeConfig> $V1_2_0_Types */
 $V1_2_0_Types = [
     new TypeConfig(
         type: UINT8,
         alignment: 'char',
         passByValue: true,
-        ops: [],
+        ops: makeDefaultTypeOps(UINT8),
         casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT8), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
     new TypeConfig(
         type: UINT16,
-        alignment: 'char',
+        alignment: 'int2',
         passByValue: true,
-        ops: [],
+        ops: makeDefaultTypeOps(UINT16),
         casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT16), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
     new TypeConfig(
         type: UINT32,
-        alignment: 'char',
+        alignment: 'int4',
         passByValue: true,
-        ops: [],
+        ops: makeDefaultTypeOps(UINT32),
         casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT32), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
     new TypeConfig(
         type: UINT64,
-        alignment: 'char',
+        alignment: 'double',
         passByValue: true,
-        ops: [],
+        ops: makeDefaultTypeOps(UINT64),
         casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT64), FLOAT4, FLOAT8, JSON, JSONB],
         inOutCasts: [NUMERIC],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
     new TypeConfig(
         type: UINT128,
         alignment: 'char',
         passByValue: false,
-        ops: [],
+        ops: makeDefaultTypeOps(UINT128),
         casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT128), FLOAT4, FLOAT8, JSON, JSONB, UUID],
         inOutCasts: [NUMERIC],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
 
@@ -77,34 +112,38 @@ $V1_2_0_Types = [
         type: INT8,
         alignment: 'char',
         passByValue: true,
-        ops: [],
+        ops: makeDefaultTypeOps(INT8),
         casts: [...UINT_TYPES, ...typesExcept(INT_TYPES, INT8), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
     new TypeConfig(
         type: INT16,
-        alignment: 'char',
+        alignment: 'int2',
+        passByValue: true,
+        ops: makeDefaultTypeOps(INT16),
         casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
     ),
     new TypeConfig(
         type: INT32,
-        alignment: 'char',
+        alignment: 'int4',
+        passByValue: true,
+        ops: makeDefaultTypeOps(INT32),
         casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
     ),
     new TypeConfig(
         type: INT64,
-        alignment: 'char',
+        alignment: 'double',
+        passByValue: true,
+        ops: makeDefaultTypeOps(INT64),
         casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
     ),
     new TypeConfig(
         type: INT128,
         alignment: 'char',
         passByValue: false,
-        ops: [],
+        ops: makeDefaultTypeOps(INT128),
         casts: [...UINT_TYPES, ...typesExcept(INT_TYPES, INT128), FLOAT4, FLOAT8, JSON, JSONB],
         inOutCasts: [NUMERIC],
-        crossTypesOnly: true,
         aggOps: AGG_OPS,
     ),
 
@@ -118,15 +157,15 @@ $V1_2_0_Types = [
 
     new TypeConfig(
         type: FLOAT4,
-        alignment: 'char',
-        passByValue: false,
+        alignment: 'int4',
+        passByValue: true,
         casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
     ),
 
     new TypeConfig(
         type: FLOAT8,
-        alignment: 'char',
-        passByValue: false,
+        alignment: 'double',
+        passByValue: true,
         casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
     ),
 

--- a/_codegen/sql/sqlgen_v1.2.0_types.php
+++ b/_codegen/sql/sqlgen_v1.2.0_types.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/sql_gen_core.php';
+
+/**
+ * @param array<Type> $types
+ * @return array<Type>
+ */
+function typesExcept(array $types, Type $except): array
+{
+    $idx = array_search($except, $types, true);
+    if ($idx === false) {
+        return $types;
+    }
+
+    $crossTypes = [];
+
+    array_push($crossTypes, ...array_slice($types, 0, $idx));
+    array_push($crossTypes, ...array_slice($types, $idx + 1));
+
+    return $crossTypes;
+}
+
+/** @var array<TypeConfig> $V1_2_0_Types */
+$V1_2_0_Types = [
+    new TypeConfig(
+        type: UINT8,
+        alignment: 'char',
+        passByValue: true,
+        ops: [],
+        casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT8), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+    new TypeConfig(
+        type: UINT16,
+        alignment: 'char',
+        passByValue: true,
+        ops: [],
+        casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT16), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+    new TypeConfig(
+        type: UINT32,
+        alignment: 'char',
+        passByValue: true,
+        ops: [],
+        casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT32), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+    new TypeConfig(
+        type: UINT64,
+        alignment: 'char',
+        passByValue: true,
+        ops: [],
+        casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT64), FLOAT4, FLOAT8, JSON, JSONB],
+        inOutCasts: [NUMERIC],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+    new TypeConfig(
+        type: UINT128,
+        alignment: 'char',
+        passByValue: false,
+        ops: [],
+        casts: [...INT_TYPES, ...typesExcept(UINT_TYPES, UINT128), FLOAT4, FLOAT8, JSON, JSONB, UUID],
+        inOutCasts: [NUMERIC],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+
+    new TypeConfig(
+        type: INT8,
+        alignment: 'char',
+        passByValue: true,
+        ops: [],
+        casts: [...UINT_TYPES, ...typesExcept(INT_TYPES, INT8), NUMERIC, FLOAT4, FLOAT8, JSON, JSONB],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+    new TypeConfig(
+        type: INT16,
+        alignment: 'char',
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+    new TypeConfig(
+        type: INT32,
+        alignment: 'char',
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+    new TypeConfig(
+        type: INT64,
+        alignment: 'char',
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+    new TypeConfig(
+        type: INT128,
+        alignment: 'char',
+        passByValue: false,
+        ops: [],
+        casts: [...UINT_TYPES, ...typesExcept(INT_TYPES, INT128), FLOAT4, FLOAT8, JSON, JSONB],
+        inOutCasts: [NUMERIC],
+        crossTypesOnly: true,
+        aggOps: AGG_OPS,
+    ),
+
+    new TypeConfig(
+        type: NUMERIC,
+        alignment: 'char',
+        passByValue: false,
+        casts: [UINT8, UINT16, UINT32, INT8],
+        inOutCasts: [UINT64, UINT128, INT128],
+    ),
+
+    new TypeConfig(
+        type: FLOAT4,
+        alignment: 'char',
+        passByValue: false,
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+
+    new TypeConfig(
+        type: FLOAT8,
+        alignment: 'char',
+        passByValue: false,
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+
+    new TypeConfig(
+        type: JSON,
+        alignment: 'char',
+        passByValue: false,
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+    new TypeConfig(
+        type: JSONB,
+        alignment: 'char',
+        passByValue: false,
+        casts: [...UINT_TYPES, ...CUSTOM_INT_TYPES],
+    ),
+    new TypeConfig(
+        type: UUID,
+        alignment: 'char',
+        passByValue: false,
+        casts: [UINT128],
+    ),
+];
+
+/**
+ * @type Type[]
+ */
+const V1_2_0_UINT_TYPES = [
+    UINT8,
+    UINT16,
+    UINT32,
+    UINT64,
+    UINT128,
+];
+
+/**
+ * @type Type[]
+ */
+const V1_2_0_INT_TYPES = [
+    INT8,
+    INT128,
+];
+
+/**
+ * @return array<TypeConfig>
+ */
+function getV1_2_0_Types(): array
+{
+    global $V1_2_0_Types;
+
+    return $V1_2_0_Types;
+}

--- a/casts/float4.c
+++ b/casts/float4.c
@@ -1,0 +1,89 @@
+// WARNING: This file is generated, do not edit
+
+#include "postgres.h"
+#include "int_utils.h"
+#include "uint_utils.h"
+#include "numeric_utils.h"
+#include "utils/fmgrprotos.h"
+#include "utils/builtins.h"
+#include "json_utils.h"
+#include <math.h>
+
+
+PG_FUNCTION_INFO_V1(float4_from_uint1);
+Datum float4_from_uint1(PG_FUNCTION_ARGS)
+{
+	uint8		arg = PG_GETARG_UINT8(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+
+PG_FUNCTION_INFO_V1(float4_from_uint2);
+Datum float4_from_uint2(PG_FUNCTION_ARGS)
+{
+	uint16		arg = PG_GETARG_UINT16(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+
+PG_FUNCTION_INFO_V1(float4_from_uint4);
+Datum float4_from_uint4(PG_FUNCTION_ARGS)
+{
+	uint32		arg = PG_GETARG_UINT32(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+
+PG_FUNCTION_INFO_V1(float4_from_uint8);
+Datum float4_from_uint8(PG_FUNCTION_ARGS)
+{
+	uint64		arg = PG_GETARG_UINT64(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+
+PG_FUNCTION_INFO_V1(float4_from_uint16);
+Datum float4_from_uint16(PG_FUNCTION_ARGS)
+{
+	uint128		arg = PG_GETARG_UINT128(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+
+PG_FUNCTION_INFO_V1(float4_from_int1);
+Datum float4_from_int1(PG_FUNCTION_ARGS)
+{
+	int8		arg = PG_GETARG_INT8(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+
+PG_FUNCTION_INFO_V1(float4_from_int16);
+Datum float4_from_int16(PG_FUNCTION_ARGS)
+{
+	int128		arg = PG_GETARG_INT128(0);
+	float4		result;
+
+	result = (float4)arg;
+
+	PG_RETURN_FLOAT4(result);
+}
+

--- a/casts/float8.c
+++ b/casts/float8.c
@@ -1,0 +1,89 @@
+// WARNING: This file is generated, do not edit
+
+#include "postgres.h"
+#include "int_utils.h"
+#include "uint_utils.h"
+#include "numeric_utils.h"
+#include "utils/fmgrprotos.h"
+#include "utils/builtins.h"
+#include "json_utils.h"
+#include <math.h>
+
+
+PG_FUNCTION_INFO_V1(float8_from_uint1);
+Datum float8_from_uint1(PG_FUNCTION_ARGS)
+{
+	uint8		arg = PG_GETARG_UINT8(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+
+PG_FUNCTION_INFO_V1(float8_from_uint2);
+Datum float8_from_uint2(PG_FUNCTION_ARGS)
+{
+	uint16		arg = PG_GETARG_UINT16(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+
+PG_FUNCTION_INFO_V1(float8_from_uint4);
+Datum float8_from_uint4(PG_FUNCTION_ARGS)
+{
+	uint32		arg = PG_GETARG_UINT32(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+
+PG_FUNCTION_INFO_V1(float8_from_uint8);
+Datum float8_from_uint8(PG_FUNCTION_ARGS)
+{
+	uint64		arg = PG_GETARG_UINT64(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+
+PG_FUNCTION_INFO_V1(float8_from_uint16);
+Datum float8_from_uint16(PG_FUNCTION_ARGS)
+{
+	uint128		arg = PG_GETARG_UINT128(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+
+PG_FUNCTION_INFO_V1(float8_from_int1);
+Datum float8_from_int1(PG_FUNCTION_ARGS)
+{
+	int8		arg = PG_GETARG_INT8(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+
+PG_FUNCTION_INFO_V1(float8_from_int16);
+Datum float8_from_int16(PG_FUNCTION_ARGS)
+{
+	int128		arg = PG_GETARG_INT128(0);
+	float8		result;
+
+	result = (float8)arg;
+
+	PG_RETURN_FLOAT8(result);
+}
+

--- a/casts/int128.c
+++ b/casts/int128.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Signed comparison
 
@@ -18,33 +19,11 @@ Datum int16_from_int1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int16_to_int1);
-Datum int16_to_int1(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a > INT8_MAX || a < INT8_MIN) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int16_from_int2);
 Datum int16_from_int2(PG_FUNCTION_ARGS) {
     int16 a = PG_GETARG_INT16(0);
 
     PG_RETURN_INT128((int128) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int16_to_int2);
-Datum int16_to_int2(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a > INT16_MAX || a < INT16_MIN) {
-        OUT_OF_RANGE_ERR(int2);
-    }
-    PG_RETURN_INT16((int16) a);
 }
 
 
@@ -56,33 +35,11 @@ Datum int16_from_int4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int16_to_int4);
-Datum int16_to_int4(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a > INT32_MAX || a < INT32_MIN) {
-        OUT_OF_RANGE_ERR(int4);
-    }
-    PG_RETURN_INT32((int32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int16_from_int8);
 Datum int16_from_int8(PG_FUNCTION_ARGS) {
     int64 a = PG_GETARG_INT64(0);
 
     PG_RETURN_INT128((int128) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int16_to_int8);
-Datum int16_to_int8(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a > INT64_MAX || a < INT64_MIN) {
-        OUT_OF_RANGE_ERR(int8);
-    }
-    PG_RETURN_INT64((int64) a);
 }
 
 
@@ -96,39 +53,11 @@ Datum int16_from_uint1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int16_to_uint1);
-Datum int16_to_uint1(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int16_from_uint2);
 Datum int16_from_uint2(PG_FUNCTION_ARGS) {
     uint16 a = PG_GETARG_UINT16(0);
 
     PG_RETURN_INT128((int128) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int16_to_uint2);
-Datum int16_to_uint2(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    if (a > UINT16_MAX) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
 }
 
 
@@ -140,39 +69,11 @@ Datum int16_from_uint4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int16_to_uint4);
-Datum int16_to_uint4(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    if (a > UINT32_MAX) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    PG_RETURN_UINT32((uint32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int16_from_uint8);
 Datum int16_from_uint8(PG_FUNCTION_ARGS) {
     uint64 a = PG_GETARG_UINT64(0);
 
     PG_RETURN_INT128((int128) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int16_to_uint8);
-Datum int16_to_uint8(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint8);
-    }
-    if (a > UINT64_MAX) {
-        OUT_OF_RANGE_ERR(uint8);
-    }
-    PG_RETURN_UINT64((uint64) a);
 }
 
 
@@ -187,51 +88,47 @@ Datum int16_from_uint16(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int16_to_uint16);
-Datum int16_to_uint16(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
+// Float casts
 
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint16);
-    }
-    PG_RETURN_UINT128((uint128) a);
+PG_FUNCTION_INFO_V1(int16_from_float4);
+Datum int16_from_float4(PG_FUNCTION_ARGS)
+{
+	float4		num = PG_GETARG_FLOAT4(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float4)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT4_FITS_IN_INT128(num)))
+		OUT_OF_RANGE_ERR(int16);
+
+	PG_RETURN_INT128((int128) num);
 }
 
+PG_FUNCTION_INFO_V1(int16_from_float8);
+Datum int16_from_float8(PG_FUNCTION_ARGS)
+{
+	float8		num = PG_GETARG_FLOAT8(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float8)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT8_FITS_IN_INT128(num)))
+		OUT_OF_RANGE_ERR(int16);
+
+	PG_RETURN_INT128((int128) num);
+}
 
 // JSON casts
-
-PG_FUNCTION_INFO_V1(int16_to_json);
-Datum int16_to_json(PG_FUNCTION_ARGS) {
-    int128 a = PG_GETARG_INT128(0);
-    char buf[INT128_STRBUFLEN];
-
-    char *bufPtr = int128_to_string(a, buf, sizeof(buf));
-
-    /* json type in Postgres is really just text with json input cast */
-    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
-
-    PG_RETURN_DATUM(result);
-}
-
-PG_FUNCTION_INFO_V1(int16_to_jsonb);
-Datum int16_to_jsonb(PG_FUNCTION_ARGS) {
-    int128 val = PG_GETARG_INT128(0);
-    JsonbValue jbv;
-    Jsonb* result;
-
-    /* convert to Numeric */
-    char buf[INT128_STRBUFLEN];
-    Numeric num = int128_to_numeric(val, buf, sizeof(buf));
-
-    /* convert Numeric to JsonbValue */
-    jbv.type = jbvNumeric;
-    jbv.val.numeric = num;
-
-    /* wrap into a Jsonb container */
-    result = JsonbValueToJsonb(&jbv);
-
-    PG_RETURN_JSONB_P(result);
-}
 
 PG_FUNCTION_INFO_V1(int16_from_json);
 Datum int16_from_json(PG_FUNCTION_ARGS)

--- a/casts/int16.c
+++ b/casts/int16.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Signed comparison
 
@@ -15,17 +16,6 @@ Datum int2_from_int1(PG_FUNCTION_ARGS) {
     int8 a = PG_GETARG_INT8(0);
 
     PG_RETURN_INT16((int16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int2_to_int1);
-Datum int2_to_int1(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    if (a > INT8_MAX || a < INT8_MIN) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
 }
 
 
@@ -40,14 +30,6 @@ Datum int2_from_int4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int2_to_int4);
-Datum int2_to_int4(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    PG_RETURN_INT32((int32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int2_from_int8);
 Datum int2_from_int8(PG_FUNCTION_ARGS) {
     int64 a = PG_GETARG_INT64(0);
@@ -56,14 +38,6 @@ Datum int2_from_int8(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int2);
     }
     PG_RETURN_INT16((int16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int2_to_int8);
-Datum int2_to_int8(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    PG_RETURN_INT64((int64) a);
 }
 
 
@@ -78,14 +52,6 @@ Datum int2_from_int16(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int2_to_int16);
-Datum int2_to_int16(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    PG_RETURN_INT128((int128) a);
-}
-
-
 // Unsigned comparison
 
 PG_FUNCTION_INFO_V1(int2_from_uint1);
@@ -93,20 +59,6 @@ Datum int2_from_uint1(PG_FUNCTION_ARGS) {
     uint8 a = PG_GETARG_UINT8(0);
 
     PG_RETURN_INT16((int16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int2_to_uint1);
-Datum int2_to_uint1(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
 }
 
 
@@ -121,17 +73,6 @@ Datum int2_from_uint2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int2_to_uint2);
-Datum int2_to_uint2(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int2_from_uint4);
 Datum int2_from_uint4(PG_FUNCTION_ARGS) {
     uint32 a = PG_GETARG_UINT32(0);
@@ -140,17 +81,6 @@ Datum int2_from_uint4(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int2);
     }
     PG_RETURN_INT16((int16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int2_to_uint4);
-Datum int2_to_uint4(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    PG_RETURN_UINT32((uint32) a);
 }
 
 
@@ -165,17 +95,6 @@ Datum int2_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int2_to_uint8);
-Datum int2_to_uint8(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint8);
-    }
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int2_from_uint16);
 Datum int2_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -184,17 +103,6 @@ Datum int2_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int2);
     }
     PG_RETURN_INT16((int16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int2_to_uint16);
-Datum int2_to_uint16(PG_FUNCTION_ARGS) {
-    int16 a = PG_GETARG_INT16(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint16);
-    }
-    PG_RETURN_UINT128((uint128) a);
 }
 
 

--- a/casts/int32.c
+++ b/casts/int32.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Signed comparison
 
@@ -18,33 +19,11 @@ Datum int4_from_int1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int4_to_int1);
-Datum int4_to_int1(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a > INT8_MAX || a < INT8_MIN) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int4_from_int2);
 Datum int4_from_int2(PG_FUNCTION_ARGS) {
     int16 a = PG_GETARG_INT16(0);
 
     PG_RETURN_INT32((int32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int4_to_int2);
-Datum int4_to_int2(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a > INT16_MAX || a < INT16_MIN) {
-        OUT_OF_RANGE_ERR(int2);
-    }
-    PG_RETURN_INT16((int16) a);
 }
 
 
@@ -59,14 +38,6 @@ Datum int4_from_int8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int4_to_int8);
-Datum int4_to_int8(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    PG_RETURN_INT64((int64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int4_from_int16);
 Datum int4_from_int16(PG_FUNCTION_ARGS) {
     int128 a = PG_GETARG_INT128(0);
@@ -75,14 +46,6 @@ Datum int4_from_int16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int4);
     }
     PG_RETURN_INT32((int32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int4_to_int16);
-Datum int4_to_int16(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    PG_RETURN_INT128((int128) a);
 }
 
 
@@ -96,39 +59,11 @@ Datum int4_from_uint1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int4_to_uint1);
-Datum int4_to_uint1(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int4_from_uint2);
 Datum int4_from_uint2(PG_FUNCTION_ARGS) {
     uint16 a = PG_GETARG_UINT16(0);
 
     PG_RETURN_INT32((int32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int4_to_uint2);
-Datum int4_to_uint2(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    if (a > UINT16_MAX) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
 }
 
 
@@ -143,17 +78,6 @@ Datum int4_from_uint4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int4_to_uint4);
-Datum int4_to_uint4(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    PG_RETURN_UINT32((uint32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int4_from_uint8);
 Datum int4_from_uint8(PG_FUNCTION_ARGS) {
     uint64 a = PG_GETARG_UINT64(0);
@@ -165,17 +89,6 @@ Datum int4_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int4_to_uint8);
-Datum int4_to_uint8(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint8);
-    }
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int4_from_uint16);
 Datum int4_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -184,17 +97,6 @@ Datum int4_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int4);
     }
     PG_RETURN_INT32((int32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int4_to_uint16);
-Datum int4_to_uint16(PG_FUNCTION_ARGS) {
-    int32 a = PG_GETARG_INT32(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint16);
-    }
-    PG_RETURN_UINT128((uint128) a);
 }
 
 

--- a/casts/int64.c
+++ b/casts/int64.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Signed comparison
 
@@ -18,17 +19,6 @@ Datum int8_from_int1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int8_to_int1);
-Datum int8_to_int1(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a > INT8_MAX || a < INT8_MIN) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int8_from_int2);
 Datum int8_from_int2(PG_FUNCTION_ARGS) {
     int16 a = PG_GETARG_INT16(0);
@@ -37,33 +27,11 @@ Datum int8_from_int2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int8_to_int2);
-Datum int8_to_int2(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a > INT16_MAX || a < INT16_MIN) {
-        OUT_OF_RANGE_ERR(int2);
-    }
-    PG_RETURN_INT16((int16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int8_from_int4);
 Datum int8_from_int4(PG_FUNCTION_ARGS) {
     int32 a = PG_GETARG_INT32(0);
 
     PG_RETURN_INT64((int64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int8_to_int4);
-Datum int8_to_int4(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a > INT32_MAX || a < INT32_MIN) {
-        OUT_OF_RANGE_ERR(int4);
-    }
-    PG_RETURN_INT32((int32) a);
 }
 
 
@@ -78,14 +46,6 @@ Datum int8_from_int16(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int8_to_int16);
-Datum int8_to_int16(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    PG_RETURN_INT128((int128) a);
-}
-
-
 // Unsigned comparison
 
 PG_FUNCTION_INFO_V1(int8_from_uint1);
@@ -93,20 +53,6 @@ Datum int8_from_uint1(PG_FUNCTION_ARGS) {
     uint8 a = PG_GETARG_UINT8(0);
 
     PG_RETURN_INT64((int64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int8_to_uint1);
-Datum int8_to_uint1(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
 }
 
 
@@ -118,39 +64,11 @@ Datum int8_from_uint2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int8_to_uint2);
-Datum int8_to_uint2(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    if (a > UINT16_MAX) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int8_from_uint4);
 Datum int8_from_uint4(PG_FUNCTION_ARGS) {
     uint32 a = PG_GETARG_UINT32(0);
 
     PG_RETURN_INT64((int64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int8_to_uint4);
-Datum int8_to_uint4(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    if (a > UINT32_MAX) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    PG_RETURN_UINT32((uint32) a);
 }
 
 
@@ -165,17 +83,6 @@ Datum int8_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int8_to_uint8);
-Datum int8_to_uint8(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint8);
-    }
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int8_from_uint16);
 Datum int8_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -184,17 +91,6 @@ Datum int8_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int8);
     }
     PG_RETURN_INT64((int64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int8_to_uint16);
-Datum int8_to_uint16(PG_FUNCTION_ARGS) {
-    int64 a = PG_GETARG_INT64(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint16);
-    }
-    PG_RETURN_UINT128((uint128) a);
 }
 
 

--- a/casts/int8.c
+++ b/casts/int8.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Signed comparison
 
@@ -21,14 +22,6 @@ Datum int1_from_int2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int1_to_int2);
-Datum int1_to_int2(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    PG_RETURN_INT16((int16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int1_from_int4);
 Datum int1_from_int4(PG_FUNCTION_ARGS) {
     int32 a = PG_GETARG_INT32(0);
@@ -37,14 +30,6 @@ Datum int1_from_int4(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int1);
     }
     PG_RETURN_INT8((int8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int1_to_int4);
-Datum int1_to_int4(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    PG_RETURN_INT32((int32) a);
 }
 
 
@@ -59,14 +44,6 @@ Datum int1_from_int8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int1_to_int8);
-Datum int1_to_int8(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    PG_RETURN_INT64((int64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int1_from_int16);
 Datum int1_from_int16(PG_FUNCTION_ARGS) {
     int128 a = PG_GETARG_INT128(0);
@@ -75,14 +52,6 @@ Datum int1_from_int16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int1);
     }
     PG_RETURN_INT8((int8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int1_to_int16);
-Datum int1_to_int16(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    PG_RETURN_INT128((int128) a);
 }
 
 
@@ -99,17 +68,6 @@ Datum int1_from_uint1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int1_to_uint1);
-Datum int1_to_uint1(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int1_from_uint2);
 Datum int1_from_uint2(PG_FUNCTION_ARGS) {
     uint16 a = PG_GETARG_UINT16(0);
@@ -118,17 +76,6 @@ Datum int1_from_uint2(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int1);
     }
     PG_RETURN_INT8((int8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int1_to_uint2);
-Datum int1_to_uint2(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
 }
 
 
@@ -143,17 +90,6 @@ Datum int1_from_uint4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int1_to_uint4);
-Datum int1_to_uint4(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    PG_RETURN_UINT32((uint32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int1_from_uint8);
 Datum int1_from_uint8(PG_FUNCTION_ARGS) {
     uint64 a = PG_GETARG_UINT64(0);
@@ -165,17 +101,6 @@ Datum int1_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(int1_to_uint8);
-Datum int1_to_uint8(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint8);
-    }
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(int1_from_uint16);
 Datum int1_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -184,17 +109,6 @@ Datum int1_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(int1);
     }
     PG_RETURN_INT8((int8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(int1_to_uint16);
-Datum int1_to_uint16(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-
-    if (a < 0) {
-        OUT_OF_RANGE_ERR(uint16);
-    }
-    PG_RETURN_UINT128((uint128) a);
 }
 
 
@@ -215,48 +129,47 @@ Datum int1_from_numeric(PG_FUNCTION_ARGS)
 	PG_RETURN_INT8((int8)numInt);
 }
 
-PG_FUNCTION_INFO_V1(int1_to_numeric);
-Datum int1_to_numeric(PG_FUNCTION_ARGS)
-{
-	int8		val = PG_GETARG_INT8(0);
+// Float casts
 
-	PG_RETURN_DATUM(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
+PG_FUNCTION_INFO_V1(int1_from_float4);
+Datum int1_from_float4(PG_FUNCTION_ARGS)
+{
+	float4		num = PG_GETARG_FLOAT4(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float4)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT4_FITS_IN_INT8(num)))
+		OUT_OF_RANGE_ERR(int1);
+
+	PG_RETURN_INT8((int8) num);
+}
+
+PG_FUNCTION_INFO_V1(int1_from_float8);
+Datum int1_from_float8(PG_FUNCTION_ARGS)
+{
+	float8		num = PG_GETARG_FLOAT8(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float8)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT8_FITS_IN_INT8(num)))
+		OUT_OF_RANGE_ERR(int1);
+
+	PG_RETURN_INT8((int8) num);
 }
 
 // JSON casts
-
-PG_FUNCTION_INFO_V1(int1_to_json);
-Datum int1_to_json(PG_FUNCTION_ARGS) {
-    int8 a = PG_GETARG_INT8(0);
-    char buf[INT8_STRBUFLEN];
-
-    char *bufPtr = int8_to_string(a, buf, sizeof(buf));
-
-    /* json type in Postgres is really just text with json input cast */
-    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
-
-    PG_RETURN_DATUM(result);
-}
-
-PG_FUNCTION_INFO_V1(int1_to_jsonb);
-Datum int1_to_jsonb(PG_FUNCTION_ARGS)
-{
-    int8 val = PG_GETARG_INT8(0);
-
-    JsonbValue jbv;
-    Jsonb* result;
-
-    Numeric num = DatumGetNumeric(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
-
-    /* convert Numeric to JsonbValue */
-    jbv.type = jbvNumeric;
-    jbv.val.numeric = num;
-
-    /* wrap into a Jsonb container */
-    result = JsonbValueToJsonb(&jbv);
-
-    PG_RETURN_JSONB_P(result);
-}
 
 PG_FUNCTION_INFO_V1(int1_from_json);
 Datum int1_from_json(PG_FUNCTION_ARGS)

--- a/casts/json.c
+++ b/casts/json.c
@@ -1,0 +1,103 @@
+// WARNING: This file is generated, do not edit
+
+#include "postgres.h"
+#include "int_utils.h"
+#include "uint_utils.h"
+#include "numeric_utils.h"
+#include "utils/fmgrprotos.h"
+#include "utils/builtins.h"
+#include "json_utils.h"
+#include <math.h>
+
+
+PG_FUNCTION_INFO_V1(json_from_uint1);
+Datum json_from_uint1(PG_FUNCTION_ARGS) {
+    uint8 a = PG_GETARG_UINT8(0);
+    char buf[UINT8_STRBUFLEN];
+
+    char *bufPtr = uint8_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+
+PG_FUNCTION_INFO_V1(json_from_uint2);
+Datum json_from_uint2(PG_FUNCTION_ARGS) {
+    uint16 a = PG_GETARG_UINT16(0);
+    char buf[UINT16_STRBUFLEN];
+
+    char *bufPtr = uint16_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+
+PG_FUNCTION_INFO_V1(json_from_uint4);
+Datum json_from_uint4(PG_FUNCTION_ARGS) {
+    uint32 a = PG_GETARG_UINT32(0);
+    char buf[UINT32_STRBUFLEN];
+
+    char *bufPtr = uint32_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+
+PG_FUNCTION_INFO_V1(json_from_uint8);
+Datum json_from_uint8(PG_FUNCTION_ARGS) {
+    uint64 a = PG_GETARG_UINT64(0);
+    char buf[UINT64_STRBUFLEN];
+
+    char *bufPtr = uint64_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+
+PG_FUNCTION_INFO_V1(json_from_uint16);
+Datum json_from_uint16(PG_FUNCTION_ARGS) {
+    uint128 a = PG_GETARG_UINT128(0);
+    char buf[UINT128_STRBUFLEN];
+
+    char *bufPtr = uint128_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+
+PG_FUNCTION_INFO_V1(json_from_int1);
+Datum json_from_int1(PG_FUNCTION_ARGS) {
+    int8 a = PG_GETARG_INT8(0);
+    char buf[INT8_STRBUFLEN];
+
+    char *bufPtr = int8_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+
+PG_FUNCTION_INFO_V1(json_from_int16);
+Datum json_from_int16(PG_FUNCTION_ARGS) {
+    int128 a = PG_GETARG_INT128(0);
+    char buf[INT128_STRBUFLEN];
+
+    char *bufPtr = int128_to_string(a, buf, sizeof(buf));
+
+    /* json type in Postgres is really just text with json input cast */
+    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
+
+    PG_RETURN_DATUM(result);
+}
+

--- a/casts/jsonb.c
+++ b/casts/jsonb.c
@@ -1,0 +1,152 @@
+// WARNING: This file is generated, do not edit
+
+#include "postgres.h"
+#include "int_utils.h"
+#include "uint_utils.h"
+#include "numeric_utils.h"
+#include "utils/fmgrprotos.h"
+#include "utils/builtins.h"
+#include "json_utils.h"
+#include <math.h>
+
+
+PG_FUNCTION_INFO_V1(jsonb_from_uint1);
+Datum jsonb_from_uint1(PG_FUNCTION_ARGS)
+{
+    uint8 val = PG_GETARG_UINT8(0);
+
+    JsonbValue jbv;
+    Jsonb* result;
+
+    Numeric num = DatumGetNumeric(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+
+PG_FUNCTION_INFO_V1(jsonb_from_uint2);
+Datum jsonb_from_uint2(PG_FUNCTION_ARGS)
+{
+    uint16 val = PG_GETARG_UINT16(0);
+
+    JsonbValue jbv;
+    Jsonb* result;
+
+    Numeric num = DatumGetNumeric(DirectFunctionCall1(int4_numeric, Int32GetDatum((int32)val)));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+
+PG_FUNCTION_INFO_V1(jsonb_from_uint4);
+Datum jsonb_from_uint4(PG_FUNCTION_ARGS)
+{
+    uint32 val = PG_GETARG_UINT32(0);
+
+    JsonbValue jbv;
+    Jsonb* result;
+
+    Numeric num = DatumGetNumeric(DirectFunctionCall1(int8_numeric, Int64GetDatum((int64)val)));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+
+PG_FUNCTION_INFO_V1(jsonb_from_uint8);
+Datum jsonb_from_uint8(PG_FUNCTION_ARGS) {
+    uint64 val = PG_GETARG_UINT64(0);
+    JsonbValue jbv;
+    Jsonb* result;
+
+    /* convert to Numeric */
+    char buf[UINT64_STRBUFLEN];
+    Numeric num = uint64_to_numeric(val, buf, sizeof(buf));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+
+PG_FUNCTION_INFO_V1(jsonb_from_uint16);
+Datum jsonb_from_uint16(PG_FUNCTION_ARGS) {
+    uint128 val = PG_GETARG_UINT128(0);
+    JsonbValue jbv;
+    Jsonb* result;
+
+    /* convert to Numeric */
+    char buf[UINT128_STRBUFLEN];
+    Numeric num = uint128_to_numeric(val, buf, sizeof(buf));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+
+PG_FUNCTION_INFO_V1(jsonb_from_int1);
+Datum jsonb_from_int1(PG_FUNCTION_ARGS)
+{
+    int8 val = PG_GETARG_INT8(0);
+
+    JsonbValue jbv;
+    Jsonb* result;
+
+    Numeric num = DatumGetNumeric(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+
+PG_FUNCTION_INFO_V1(jsonb_from_int16);
+Datum jsonb_from_int16(PG_FUNCTION_ARGS) {
+    int128 val = PG_GETARG_INT128(0);
+    JsonbValue jbv;
+    Jsonb* result;
+
+    /* convert to Numeric */
+    char buf[INT128_STRBUFLEN];
+    Numeric num = int128_to_numeric(val, buf, sizeof(buf));
+
+    /* convert Numeric to JsonbValue */
+    jbv.type = jbvNumeric;
+    jbv.val.numeric = num;
+
+    /* wrap into a Jsonb container */
+    result = JsonbValueToJsonb(&jbv);
+
+    PG_RETURN_JSONB_P(result);
+}
+

--- a/casts/numeric.c
+++ b/casts/numeric.c
@@ -1,0 +1,50 @@
+// WARNING: This file is generated, do not edit
+
+#include "postgres.h"
+#include "int_utils.h"
+#include "uint_utils.h"
+#include "numeric_utils.h"
+#include "utils/fmgrprotos.h"
+#include "utils/builtins.h"
+#include "json_utils.h"
+#include <math.h>
+
+
+PG_FUNCTION_INFO_V1(numeric_from_uint1);
+Datum numeric_from_uint1(PG_FUNCTION_ARGS)
+{
+	uint8		val = PG_GETARG_UINT8(0);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
+}
+
+PG_FUNCTION_INFO_V1(numeric_from_uint2);
+Datum numeric_from_uint2(PG_FUNCTION_ARGS)
+{
+	uint16		val = PG_GETARG_UINT16(0);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(int4_numeric, Int32GetDatum((int32)val)));
+}
+
+PG_FUNCTION_INFO_V1(numeric_from_uint4);
+Datum numeric_from_uint4(PG_FUNCTION_ARGS)
+{
+	uint32		val = PG_GETARG_UINT32(0);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(int8_numeric, Int64GetDatum((int64)val)));
+}
+
+
+
+
+
+PG_FUNCTION_INFO_V1(numeric_from_int1);
+Datum numeric_from_int1(PG_FUNCTION_ARGS)
+{
+	int8		val = PG_GETARG_INT8(0);
+
+	PG_RETURN_DATUM(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
+}
+
+
+

--- a/casts/uint16.c
+++ b/casts/uint16.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Unsigned casts
 
@@ -15,17 +16,6 @@ Datum uint2_from_uint1(PG_FUNCTION_ARGS) {
     uint8 a = PG_GETARG_UINT8(0);
 
     PG_RETURN_UINT16((uint16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint2_to_uint1);
-Datum uint2_to_uint1(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
 }
 
 
@@ -40,14 +30,6 @@ Datum uint2_from_uint4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint2_to_uint4);
-Datum uint2_to_uint4(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    PG_RETURN_UINT32((uint32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint2_from_uint8);
 Datum uint2_from_uint8(PG_FUNCTION_ARGS) {
     uint64 a = PG_GETARG_UINT64(0);
@@ -59,14 +41,6 @@ Datum uint2_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint2_to_uint8);
-Datum uint2_to_uint8(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint2_from_uint16);
 Datum uint2_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -75,14 +49,6 @@ Datum uint2_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint2);
     }
     PG_RETURN_UINT16((uint16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint2_to_uint16);
-Datum uint2_to_uint16(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    PG_RETURN_UINT128((uint128) a);
 }
 
 
@@ -99,17 +65,6 @@ Datum uint2_from_int1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint2_to_int1);
-Datum uint2_to_int1(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    if (a > INT8_MAX) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint2_from_int2);
 Datum uint2_from_int2(PG_FUNCTION_ARGS) {
     int16 a = PG_GETARG_INT16(0);
@@ -118,17 +73,6 @@ Datum uint2_from_int2(PG_FUNCTION_ARGS) {
     }
 
     PG_RETURN_UINT16((uint16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint2_to_int2);
-Datum uint2_to_int2(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    if (a > INT16_MAX) {
-        OUT_OF_RANGE_ERR(int2);
-    }
-    PG_RETURN_INT16((int16) a);
 }
 
 
@@ -146,14 +90,6 @@ Datum uint2_from_int4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint2_to_int4);
-Datum uint2_to_int4(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    PG_RETURN_INT32((int32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint2_from_int8);
 Datum uint2_from_int8(PG_FUNCTION_ARGS) {
     int64 a = PG_GETARG_INT64(0);
@@ -168,14 +104,6 @@ Datum uint2_from_int8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint2_to_int8);
-Datum uint2_to_int8(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    PG_RETURN_INT64((int64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint2_from_int16);
 Datum uint2_from_int16(PG_FUNCTION_ARGS) {
     int128 a = PG_GETARG_INT128(0);
@@ -187,14 +115,6 @@ Datum uint2_from_int16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint2);
     }
     PG_RETURN_UINT16((uint16) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint2_to_int16);
-Datum uint2_to_int16(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-
-    PG_RETURN_INT128((int128) a);
 }
 
 
@@ -215,48 +135,47 @@ Datum uint2_from_numeric(PG_FUNCTION_ARGS)
 	PG_RETURN_UINT16((uint16)numInt);
 }
 
-PG_FUNCTION_INFO_V1(uint2_to_numeric);
-Datum uint2_to_numeric(PG_FUNCTION_ARGS)
-{
-	uint16		val = PG_GETARG_UINT16(0);
+// Float casts
 
-	PG_RETURN_DATUM(DirectFunctionCall1(int4_numeric, Int32GetDatum((int32)val)));
+PG_FUNCTION_INFO_V1(uint2_from_float4);
+Datum uint2_from_float4(PG_FUNCTION_ARGS)
+{
+	float4		num = PG_GETARG_FLOAT4(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float4)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT4_FITS_IN_UINT16(num)))
+		OUT_OF_RANGE_ERR(uint2);
+
+	PG_RETURN_UINT16((uint16) num);
+}
+
+PG_FUNCTION_INFO_V1(uint2_from_float8);
+Datum uint2_from_float8(PG_FUNCTION_ARGS)
+{
+	float8		num = PG_GETARG_FLOAT8(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float8)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT8_FITS_IN_UINT16(num)))
+		OUT_OF_RANGE_ERR(uint2);
+
+	PG_RETURN_UINT16((uint16) num);
 }
 
 // JSON casts
-
-PG_FUNCTION_INFO_V1(uint2_to_json);
-Datum uint2_to_json(PG_FUNCTION_ARGS) {
-    uint16 a = PG_GETARG_UINT16(0);
-    char buf[UINT16_STRBUFLEN];
-
-    char *bufPtr = uint16_to_string(a, buf, sizeof(buf));
-
-    /* json type in Postgres is really just text with json input cast */
-    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
-
-    PG_RETURN_DATUM(result);
-}
-
-PG_FUNCTION_INFO_V1(uint2_to_jsonb);
-Datum uint2_to_jsonb(PG_FUNCTION_ARGS)
-{
-    uint16 val = PG_GETARG_UINT16(0);
-
-    JsonbValue jbv;
-    Jsonb* result;
-
-    Numeric num = DatumGetNumeric(DirectFunctionCall1(int4_numeric, Int32GetDatum((int32)val)));
-
-    /* convert Numeric to JsonbValue */
-    jbv.type = jbvNumeric;
-    jbv.val.numeric = num;
-
-    /* wrap into a Jsonb container */
-    result = JsonbValueToJsonb(&jbv);
-
-    PG_RETURN_JSONB_P(result);
-}
 
 PG_FUNCTION_INFO_V1(uint2_from_json);
 Datum uint2_from_json(PG_FUNCTION_ARGS)

--- a/casts/uint32.c
+++ b/casts/uint32.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Unsigned casts
 
@@ -18,33 +19,11 @@ Datum uint4_from_uint1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint4_to_uint1);
-Datum uint4_to_uint1(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint4_from_uint2);
 Datum uint4_from_uint2(PG_FUNCTION_ARGS) {
     uint16 a = PG_GETARG_UINT16(0);
 
     PG_RETURN_UINT32((uint32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint4_to_uint2);
-Datum uint4_to_uint2(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    if (a > UINT16_MAX) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
 }
 
 
@@ -59,14 +38,6 @@ Datum uint4_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint4_to_uint8);
-Datum uint4_to_uint8(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint4_from_uint16);
 Datum uint4_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -75,14 +46,6 @@ Datum uint4_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint4);
     }
     PG_RETURN_UINT32((uint32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint4_to_uint16);
-Datum uint4_to_uint16(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    PG_RETURN_UINT128((uint128) a);
 }
 
 
@@ -99,17 +62,6 @@ Datum uint4_from_int1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint4_to_int1);
-Datum uint4_to_int1(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    if (a > INT8_MAX) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint4_from_int2);
 Datum uint4_from_int2(PG_FUNCTION_ARGS) {
     int16 a = PG_GETARG_INT16(0);
@@ -121,17 +73,6 @@ Datum uint4_from_int2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint4_to_int2);
-Datum uint4_to_int2(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    if (a > INT16_MAX) {
-        OUT_OF_RANGE_ERR(int2);
-    }
-    PG_RETURN_INT16((int16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint4_from_int4);
 Datum uint4_from_int4(PG_FUNCTION_ARGS) {
     int32 a = PG_GETARG_INT32(0);
@@ -140,17 +81,6 @@ Datum uint4_from_int4(PG_FUNCTION_ARGS) {
     }
 
     PG_RETURN_UINT32((uint32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint4_to_int4);
-Datum uint4_to_int4(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    if (a > INT32_MAX) {
-        OUT_OF_RANGE_ERR(int4);
-    }
-    PG_RETURN_INT32((int32) a);
 }
 
 
@@ -168,14 +98,6 @@ Datum uint4_from_int8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint4_to_int8);
-Datum uint4_to_int8(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    PG_RETURN_INT64((int64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint4_from_int16);
 Datum uint4_from_int16(PG_FUNCTION_ARGS) {
     int128 a = PG_GETARG_INT128(0);
@@ -187,14 +109,6 @@ Datum uint4_from_int16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint4);
     }
     PG_RETURN_UINT32((uint32) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint4_to_int16);
-Datum uint4_to_int16(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-
-    PG_RETURN_INT128((int128) a);
 }
 
 
@@ -215,48 +129,47 @@ Datum uint4_from_numeric(PG_FUNCTION_ARGS)
 	PG_RETURN_UINT32((uint32)numInt);
 }
 
-PG_FUNCTION_INFO_V1(uint4_to_numeric);
-Datum uint4_to_numeric(PG_FUNCTION_ARGS)
-{
-	uint32		val = PG_GETARG_UINT32(0);
+// Float casts
 
-	PG_RETURN_DATUM(DirectFunctionCall1(int8_numeric, Int64GetDatum((int64)val)));
+PG_FUNCTION_INFO_V1(uint4_from_float4);
+Datum uint4_from_float4(PG_FUNCTION_ARGS)
+{
+	float4		num = PG_GETARG_FLOAT4(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float4)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT4_FITS_IN_UINT32(num)))
+		OUT_OF_RANGE_ERR(uint4);
+
+	PG_RETURN_UINT32((uint32) num);
+}
+
+PG_FUNCTION_INFO_V1(uint4_from_float8);
+Datum uint4_from_float8(PG_FUNCTION_ARGS)
+{
+	float8		num = PG_GETARG_FLOAT8(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float8)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT8_FITS_IN_UINT32(num)))
+		OUT_OF_RANGE_ERR(uint4);
+
+	PG_RETURN_UINT32((uint32) num);
 }
 
 // JSON casts
-
-PG_FUNCTION_INFO_V1(uint4_to_json);
-Datum uint4_to_json(PG_FUNCTION_ARGS) {
-    uint32 a = PG_GETARG_UINT32(0);
-    char buf[UINT32_STRBUFLEN];
-
-    char *bufPtr = uint32_to_string(a, buf, sizeof(buf));
-
-    /* json type in Postgres is really just text with json input cast */
-    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
-
-    PG_RETURN_DATUM(result);
-}
-
-PG_FUNCTION_INFO_V1(uint4_to_jsonb);
-Datum uint4_to_jsonb(PG_FUNCTION_ARGS)
-{
-    uint32 val = PG_GETARG_UINT32(0);
-
-    JsonbValue jbv;
-    Jsonb* result;
-
-    Numeric num = DatumGetNumeric(DirectFunctionCall1(int8_numeric, Int64GetDatum((int64)val)));
-
-    /* convert Numeric to JsonbValue */
-    jbv.type = jbvNumeric;
-    jbv.val.numeric = num;
-
-    /* wrap into a Jsonb container */
-    result = JsonbValueToJsonb(&jbv);
-
-    PG_RETURN_JSONB_P(result);
-}
 
 PG_FUNCTION_INFO_V1(uint4_from_json);
 Datum uint4_from_json(PG_FUNCTION_ARGS)

--- a/casts/uint64.c
+++ b/casts/uint64.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Unsigned casts
 
@@ -18,33 +19,11 @@ Datum uint8_from_uint1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint8_to_uint1);
-Datum uint8_to_uint1(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > UINT8_MAX) {
-        OUT_OF_RANGE_ERR(uint1);
-    }
-    PG_RETURN_UINT8((uint8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint8_from_uint2);
 Datum uint8_from_uint2(PG_FUNCTION_ARGS) {
     uint16 a = PG_GETARG_UINT16(0);
 
     PG_RETURN_UINT64((uint64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint8_to_uint2);
-Datum uint8_to_uint2(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > UINT16_MAX) {
-        OUT_OF_RANGE_ERR(uint2);
-    }
-    PG_RETURN_UINT16((uint16) a);
 }
 
 
@@ -56,17 +35,6 @@ Datum uint8_from_uint4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint8_to_uint4);
-Datum uint8_to_uint4(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > UINT32_MAX) {
-        OUT_OF_RANGE_ERR(uint4);
-    }
-    PG_RETURN_UINT32((uint32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint8_from_uint16);
 Datum uint8_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -75,14 +43,6 @@ Datum uint8_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint8);
     }
     PG_RETURN_UINT64((uint64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint8_to_uint16);
-Datum uint8_to_uint16(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    PG_RETURN_UINT128((uint128) a);
 }
 
 
@@ -99,17 +59,6 @@ Datum uint8_from_int1(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint8_to_int1);
-Datum uint8_to_int1(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > INT8_MAX) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint8_from_int2);
 Datum uint8_from_int2(PG_FUNCTION_ARGS) {
     int16 a = PG_GETARG_INT16(0);
@@ -118,17 +67,6 @@ Datum uint8_from_int2(PG_FUNCTION_ARGS) {
     }
 
     PG_RETURN_UINT64((uint64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint8_to_int2);
-Datum uint8_to_int2(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > INT16_MAX) {
-        OUT_OF_RANGE_ERR(int2);
-    }
-    PG_RETURN_INT16((int16) a);
 }
 
 
@@ -143,17 +81,6 @@ Datum uint8_from_int4(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint8_to_int4);
-Datum uint8_to_int4(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > INT32_MAX) {
-        OUT_OF_RANGE_ERR(int4);
-    }
-    PG_RETURN_INT32((int32) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint8_from_int8);
 Datum uint8_from_int8(PG_FUNCTION_ARGS) {
     int64 a = PG_GETARG_INT64(0);
@@ -162,17 +89,6 @@ Datum uint8_from_int8(PG_FUNCTION_ARGS) {
     }
 
     PG_RETURN_UINT64((uint64) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint8_to_int8);
-Datum uint8_to_int8(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-
-    if (a > INT64_MAX) {
-        OUT_OF_RANGE_ERR(int8);
-    }
-    PG_RETURN_INT64((int64) a);
 }
 
 
@@ -190,48 +106,47 @@ Datum uint8_from_int16(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint8_to_int16);
-Datum uint8_to_int16(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
+// Float casts
 
-    PG_RETURN_INT128((int128) a);
+PG_FUNCTION_INFO_V1(uint8_from_float4);
+Datum uint8_from_float4(PG_FUNCTION_ARGS)
+{
+	float4		num = PG_GETARG_FLOAT4(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float4)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT4_FITS_IN_UINT64(num)))
+		OUT_OF_RANGE_ERR(uint8);
+
+	PG_RETURN_UINT64((uint64) num);
 }
 
+PG_FUNCTION_INFO_V1(uint8_from_float8);
+Datum uint8_from_float8(PG_FUNCTION_ARGS)
+{
+	float8		num = PG_GETARG_FLOAT8(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float8)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT8_FITS_IN_UINT64(num)))
+		OUT_OF_RANGE_ERR(uint8);
+
+	PG_RETURN_UINT64((uint64) num);
+}
 
 // JSON casts
-
-PG_FUNCTION_INFO_V1(uint8_to_json);
-Datum uint8_to_json(PG_FUNCTION_ARGS) {
-    uint64 a = PG_GETARG_UINT64(0);
-    char buf[UINT64_STRBUFLEN];
-
-    char *bufPtr = uint64_to_string(a, buf, sizeof(buf));
-
-    /* json type in Postgres is really just text with json input cast */
-    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
-
-    PG_RETURN_DATUM(result);
-}
-
-PG_FUNCTION_INFO_V1(uint8_to_jsonb);
-Datum uint8_to_jsonb(PG_FUNCTION_ARGS) {
-    uint64 val = PG_GETARG_UINT64(0);
-    JsonbValue jbv;
-    Jsonb* result;
-
-    /* convert to Numeric */
-    char buf[UINT64_STRBUFLEN];
-    Numeric num = uint64_to_numeric(val, buf, sizeof(buf));
-
-    /* convert Numeric to JsonbValue */
-    jbv.type = jbvNumeric;
-    jbv.val.numeric = num;
-
-    /* wrap into a Jsonb container */
-    result = JsonbValueToJsonb(&jbv);
-
-    PG_RETURN_JSONB_P(result);
-}
 
 PG_FUNCTION_INFO_V1(uint8_from_json);
 Datum uint8_from_json(PG_FUNCTION_ARGS)

--- a/casts/uint8.c
+++ b/casts/uint8.c
@@ -7,6 +7,7 @@
 #include "utils/fmgrprotos.h"
 #include "utils/builtins.h"
 #include "json_utils.h"
+#include <math.h>
 
 // Unsigned casts
 
@@ -21,14 +22,6 @@ Datum uint1_from_uint2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint1_to_uint2);
-Datum uint1_to_uint2(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_UINT16((uint16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint1_from_uint4);
 Datum uint1_from_uint4(PG_FUNCTION_ARGS) {
     uint32 a = PG_GETARG_UINT32(0);
@@ -37,14 +30,6 @@ Datum uint1_from_uint4(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint1);
     }
     PG_RETURN_UINT8((uint8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint1_to_uint4);
-Datum uint1_to_uint4(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_UINT32((uint32) a);
 }
 
 
@@ -59,14 +44,6 @@ Datum uint1_from_uint8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint1_to_uint8);
-Datum uint1_to_uint8(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_UINT64((uint64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint1_from_uint16);
 Datum uint1_from_uint16(PG_FUNCTION_ARGS) {
     uint128 a = PG_GETARG_UINT128(0);
@@ -75,14 +52,6 @@ Datum uint1_from_uint16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint1);
     }
     PG_RETURN_UINT8((uint8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint1_to_uint16);
-Datum uint1_to_uint16(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_UINT128((uint128) a);
 }
 
 
@@ -96,17 +65,6 @@ Datum uint1_from_int1(PG_FUNCTION_ARGS) {
     }
 
     PG_RETURN_UINT8((uint8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint1_to_int1);
-Datum uint1_to_int1(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    if (a > INT8_MAX) {
-        OUT_OF_RANGE_ERR(int1);
-    }
-    PG_RETURN_INT8((int8) a);
 }
 
 
@@ -124,14 +82,6 @@ Datum uint1_from_int2(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint1_to_int2);
-Datum uint1_to_int2(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_INT16((int16) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint1_from_int4);
 Datum uint1_from_int4(PG_FUNCTION_ARGS) {
     int32 a = PG_GETARG_INT32(0);
@@ -143,14 +93,6 @@ Datum uint1_from_int4(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint1);
     }
     PG_RETURN_UINT8((uint8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint1_to_int4);
-Datum uint1_to_int4(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_INT32((int32) a);
 }
 
 
@@ -168,14 +110,6 @@ Datum uint1_from_int8(PG_FUNCTION_ARGS) {
 }
 
 
-PG_FUNCTION_INFO_V1(uint1_to_int8);
-Datum uint1_to_int8(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_INT64((int64) a);
-}
-
-
 PG_FUNCTION_INFO_V1(uint1_from_int16);
 Datum uint1_from_int16(PG_FUNCTION_ARGS) {
     int128 a = PG_GETARG_INT128(0);
@@ -187,14 +121,6 @@ Datum uint1_from_int16(PG_FUNCTION_ARGS) {
         OUT_OF_RANGE_ERR(uint1);
     }
     PG_RETURN_UINT8((uint8) a);
-}
-
-
-PG_FUNCTION_INFO_V1(uint1_to_int16);
-Datum uint1_to_int16(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-
-    PG_RETURN_INT128((int128) a);
 }
 
 
@@ -215,48 +141,47 @@ Datum uint1_from_numeric(PG_FUNCTION_ARGS)
 	PG_RETURN_UINT8((uint8)numInt);
 }
 
-PG_FUNCTION_INFO_V1(uint1_to_numeric);
-Datum uint1_to_numeric(PG_FUNCTION_ARGS)
-{
-	uint8		val = PG_GETARG_UINT8(0);
+// Float casts
 
-	PG_RETURN_DATUM(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
+PG_FUNCTION_INFO_V1(uint1_from_float4);
+Datum uint1_from_float4(PG_FUNCTION_ARGS)
+{
+	float4		num = PG_GETARG_FLOAT4(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float4)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT4_FITS_IN_UINT8(num)))
+		OUT_OF_RANGE_ERR(uint1);
+
+	PG_RETURN_UINT8((uint8) num);
+}
+
+PG_FUNCTION_INFO_V1(uint1_from_float8);
+Datum uint1_from_float8(PG_FUNCTION_ARGS)
+{
+	float8		num = PG_GETARG_FLOAT8(0);
+
+	/*
+	 * Get rid of any fractional part in the input.  This is so we don't fail
+	 * on just-out-of-range values that would round into range.  Note
+	 * assumption that rint() will pass through a NaN or Inf unchanged.
+	 */
+	num = (float8)rint(num);
+
+	/* Range check */
+	if (unlikely(isnan(num) || !FLOAT8_FITS_IN_UINT8(num)))
+		OUT_OF_RANGE_ERR(uint1);
+
+	PG_RETURN_UINT8((uint8) num);
 }
 
 // JSON casts
-
-PG_FUNCTION_INFO_V1(uint1_to_json);
-Datum uint1_to_json(PG_FUNCTION_ARGS) {
-    uint8 a = PG_GETARG_UINT8(0);
-    char buf[UINT8_STRBUFLEN];
-
-    char *bufPtr = uint8_to_string(a, buf, sizeof(buf));
-
-    /* json type in Postgres is really just text with json input cast */
-    Datum result = DirectFunctionCall1(json_in, CStringGetDatum(bufPtr));
-
-    PG_RETURN_DATUM(result);
-}
-
-PG_FUNCTION_INFO_V1(uint1_to_jsonb);
-Datum uint1_to_jsonb(PG_FUNCTION_ARGS)
-{
-    uint8 val = PG_GETARG_UINT8(0);
-
-    JsonbValue jbv;
-    Jsonb* result;
-
-    Numeric num = DatumGetNumeric(DirectFunctionCall1(int2_numeric, Int16GetDatum((int16)val)));
-
-    /* convert Numeric to JsonbValue */
-    jbv.type = jbvNumeric;
-    jbv.val.numeric = num;
-
-    /* wrap into a Jsonb container */
-    result = JsonbValueToJsonb(&jbv);
-
-    PG_RETURN_JSONB_P(result);
-}
 
 PG_FUNCTION_INFO_V1(uint1_from_json);
 Datum uint1_from_json(PG_FUNCTION_ARGS)

--- a/codegen.php
+++ b/codegen.php
@@ -14,10 +14,12 @@ if (!array_key_exists(1, $argv) || $argv[1] === "--sql-only") {
     include __DIR__ . '/_codegen/sql/sqlgen_v1.0.0.php';
     include __DIR__ . '/_codegen/sql/sqlgen_v1.1.0.php';
     include __DIR__ . '/_codegen/sql/sqlgen_v1.1.1.php';
+    include __DIR__ . '/_codegen/sql/sqlgen_v1.2.0.php';
 
     $v1_0_0 = file_get_contents(__DIR__ . '/uint128--1.0.0.sql');
     $v1_1_0 = file_get_contents(__DIR__ . '/uint128--1.0.1--1.1.0.sql');
     $v1_1_1 = file_get_contents(__DIR__ . '/uint128--1.1.0--1.1.1.sql');
+    $v1_2_0 = file_get_contents(__DIR__ . '/uint128--1.1.1--1.2.0.sql');
 
     file_put_contents(__DIR__ . '/uint128--1.1.0.sql', $v1_0_0 . "--\n-- v1.1.0\n--\n\n" . $v1_1_0);
     file_put_contents(__DIR__ . '/uint128--1.1.1.sql', $v1_0_0 . "--\n-- v1.1.0\n--\n\n" . $v1_1_0. "--\n-- v1.1.1\n--\n\n" . $v1_1_1);

--- a/expected/test_int1.out
+++ b/expected/test_int1.out
@@ -952,7 +952,7 @@ SELECT s FROM generate_series(1::int1, 10::int1, 2::int1) s;
 (5 rows)
 
 -- Ranges block
-SELECT int1range(0, 10);
+SELECT int1range(0::int1, 10::int1);
  int1range 
 -----------
  [0,10)
@@ -966,55 +966,55 @@ SELECT int1range((-128)::int1, 127::int1);
 
 SELECT int1range((-128)::int1, 127::int1, '[]');
 ERROR:  int1 out of range
-SELECT upper(int1range(0, 10));
+SELECT upper(int1range(0::int1, 10::int1));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(int1range(0, 10));
+SELECT lower(int1range(0::int1, 10::int1));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(int1range(0, 10));
+SELECT isempty(int1range(0::int1, 10::int1));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT int1range(0, 10) @> 9::int1;
+SELECT int1range(0::int1, 10::int1) @> 9::int1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT int1range(0, 10) @> 10::int1;
+SELECT int1range(0::int1, 10::int1) @> 10::int1;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT int1range(0, 10) && int1range(10,20);
+SELECT int1range(0::int1, 10::int1) && int1range(10::int1,20::int1);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT int1range(0, 10) && int1range(9,20);
+SELECT int1range(0::int1, 10::int1) && int1range(9::int1,20::int1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT int1range(5, 10) - int1range(5, 10);
+SELECT int1range(5::int1, 10::int1) - int1range(5::int1, 10::int1);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT int1range(5, 10) - int1range(5, 9);
+SELECT int1range(5::int1, 10::int1) - int1range(5::int1, 9::int1);
  ?column? 
 ----------
  [9,10)
@@ -1024,9 +1024,9 @@ CREATE TEMPORARY TABLE test_int1range (
     r int1range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_int1range (r) VALUES (int1range(0, 10));
-INSERT INTO test_int1range (r) VALUES (int1range(10, 20));
-INSERT INTO test_int1range (r) VALUES (int1range(19, 30));
+INSERT INTO test_int1range (r) VALUES (int1range(0::int1, 10::int1));
+INSERT INTO test_int1range (r) VALUES (int1range(10::int1, 20::int1));
+INSERT INTO test_int1range (r) VALUES (int1range(19::int1, 30::int1));
 ERROR:  conflicting key value violates exclusion constraint "test_int1range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_int1range;

--- a/expected/test_int16.out
+++ b/expected/test_int16.out
@@ -952,7 +952,7 @@ SELECT s FROM generate_series(1::int16, 10::int16, 2::int16) s;
 (5 rows)
 
 -- Ranges block
-SELECT int16range(0, 10);
+SELECT int16range(0::int16, 10::int16);
  int16range 
 ------------
  [0,10)
@@ -966,55 +966,55 @@ SELECT int16range((-170141183460469231731687303715884105728)::int16, 17014118346
 
 SELECT int16range((-170141183460469231731687303715884105728)::int16, 170141183460469231731687303715884105727::int16, '[]');
 ERROR:  int16 out of range
-SELECT upper(int16range(0, 10));
+SELECT upper(int16range(0::int16, 10::int16));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(int16range(0, 10));
+SELECT lower(int16range(0::int16, 10::int16));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(int16range(0, 10));
+SELECT isempty(int16range(0::int16, 10::int16));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT int16range(0, 10) @> 9::int16;
+SELECT int16range(0::int16, 10::int16) @> 9::int16;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT int16range(0, 10) @> 10::int16;
+SELECT int16range(0::int16, 10::int16) @> 10::int16;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT int16range(0, 10) && int16range(10,20);
+SELECT int16range(0::int16, 10::int16) && int16range(10::int16,20::int16);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT int16range(0, 10) && int16range(9,20);
+SELECT int16range(0::int16, 10::int16) && int16range(9::int16,20::int16);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT int16range(5, 10) - int16range(5, 10);
+SELECT int16range(5::int16, 10::int16) - int16range(5::int16, 10::int16);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT int16range(5, 10) - int16range(5, 9);
+SELECT int16range(5::int16, 10::int16) - int16range(5::int16, 9::int16);
  ?column? 
 ----------
  [9,10)
@@ -1024,9 +1024,9 @@ CREATE TEMPORARY TABLE test_int16range (
     r int16range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_int16range (r) VALUES (int16range(0, 10));
-INSERT INTO test_int16range (r) VALUES (int16range(10, 20));
-INSERT INTO test_int16range (r) VALUES (int16range(19, 30));
+INSERT INTO test_int16range (r) VALUES (int16range(0::int16, 10::int16));
+INSERT INTO test_int16range (r) VALUES (int16range(10::int16, 20::int16));
+INSERT INTO test_int16range (r) VALUES (int16range(19::int16, 30::int16));
 ERROR:  conflicting key value violates exclusion constraint "test_int16range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_int16range;

--- a/expected/test_uint1.out
+++ b/expected/test_uint1.out
@@ -1042,7 +1042,7 @@ SELECT s FROM generate_series(1::uint1, 10::uint1, 2::uint1) s;
 (5 rows)
 
 -- Ranges block
-SELECT uint1range(0, 10);
+SELECT uint1range(0::uint1, 10::uint1);
  uint1range 
 ------------
  [0,10)
@@ -1056,55 +1056,55 @@ SELECT uint1range(0::uint1, 255::uint1);
 
 SELECT uint1range(0::uint1, 255::uint1, '[]');
 ERROR:  uint1 out of range
-SELECT upper(uint1range(0, 10));
+SELECT upper(uint1range(0::uint1, 10::uint1));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(uint1range(0, 10));
+SELECT lower(uint1range(0::uint1, 10::uint1));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(uint1range(0, 10));
+SELECT isempty(uint1range(0::uint1, 10::uint1));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT uint1range(0, 10) @> 9::uint1;
+SELECT uint1range(0::uint1, 10::uint1) @> 9::uint1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint1range(0, 10) @> 10::uint1;
+SELECT uint1range(0::uint1, 10::uint1) @> 10::uint1;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint1range(0, 10) && uint1range(10,20);
+SELECT uint1range(0::uint1, 10::uint1) && uint1range(10::uint1,20::uint1);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint1range(0, 10) && uint1range(9,20);
+SELECT uint1range(0::uint1, 10::uint1) && uint1range(9::uint1,20::uint1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint1range(5, 10) - uint1range(5, 10);
+SELECT uint1range(5::uint1, 10::uint1) - uint1range(5::uint1, 10::uint1);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT uint1range(5, 10) - uint1range(5, 9);
+SELECT uint1range(5::uint1, 10::uint1) - uint1range(5::uint1, 9::uint1);
  ?column? 
 ----------
  [9,10)
@@ -1114,9 +1114,9 @@ CREATE TEMPORARY TABLE test_uint1range (
     r uint1range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_uint1range (r) VALUES (uint1range(0, 10));
-INSERT INTO test_uint1range (r) VALUES (uint1range(10, 20));
-INSERT INTO test_uint1range (r) VALUES (uint1range(19, 30));
+INSERT INTO test_uint1range (r) VALUES (uint1range(0::uint1, 10::uint1));
+INSERT INTO test_uint1range (r) VALUES (uint1range(10::uint1, 20::uint1));
+INSERT INTO test_uint1range (r) VALUES (uint1range(19::uint1, 30::uint1));
 ERROR:  conflicting key value violates exclusion constraint "test_uint1range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_uint1range;

--- a/expected/test_uint16.out
+++ b/expected/test_uint16.out
@@ -1042,7 +1042,7 @@ SELECT s FROM generate_series(1::uint16, 10::uint16, 2::uint16) s;
 (5 rows)
 
 -- Ranges block
-SELECT uint16range(0, 10);
+SELECT uint16range(0::uint16, 10::uint16);
  uint16range 
 -------------
  [0,10)
@@ -1056,55 +1056,55 @@ SELECT uint16range(0::uint16, 340282366920938463463374607431768211455::uint16);
 
 SELECT uint16range(0::uint16, 340282366920938463463374607431768211455::uint16, '[]');
 ERROR:  uint16 out of range
-SELECT upper(uint16range(0, 10));
+SELECT upper(uint16range(0::uint16, 10::uint16));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(uint16range(0, 10));
+SELECT lower(uint16range(0::uint16, 10::uint16));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(uint16range(0, 10));
+SELECT isempty(uint16range(0::uint16, 10::uint16));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT uint16range(0, 10) @> 9::uint16;
+SELECT uint16range(0::uint16, 10::uint16) @> 9::uint16;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint16range(0, 10) @> 10::uint16;
+SELECT uint16range(0::uint16, 10::uint16) @> 10::uint16;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint16range(0, 10) && uint16range(10,20);
+SELECT uint16range(0::uint16, 10::uint16) && uint16range(10::uint16,20::uint16);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint16range(0, 10) && uint16range(9,20);
+SELECT uint16range(0::uint16, 10::uint16) && uint16range(9::uint16,20::uint16);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint16range(5, 10) - uint16range(5, 10);
+SELECT uint16range(5::uint16, 10::uint16) - uint16range(5::uint16, 10::uint16);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT uint16range(5, 10) - uint16range(5, 9);
+SELECT uint16range(5::uint16, 10::uint16) - uint16range(5::uint16, 9::uint16);
  ?column? 
 ----------
  [9,10)
@@ -1114,9 +1114,9 @@ CREATE TEMPORARY TABLE test_uint16range (
     r uint16range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_uint16range (r) VALUES (uint16range(0, 10));
-INSERT INTO test_uint16range (r) VALUES (uint16range(10, 20));
-INSERT INTO test_uint16range (r) VALUES (uint16range(19, 30));
+INSERT INTO test_uint16range (r) VALUES (uint16range(0::uint16, 10::uint16));
+INSERT INTO test_uint16range (r) VALUES (uint16range(10::uint16, 20::uint16));
+INSERT INTO test_uint16range (r) VALUES (uint16range(19::uint16, 30::uint16));
 ERROR:  conflicting key value violates exclusion constraint "test_uint16range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_uint16range;

--- a/expected/test_uint2.out
+++ b/expected/test_uint2.out
@@ -1042,7 +1042,7 @@ SELECT s FROM generate_series(1::uint2, 10::uint2, 2::uint2) s;
 (5 rows)
 
 -- Ranges block
-SELECT uint2range(0, 10);
+SELECT uint2range(0::uint2, 10::uint2);
  uint2range 
 ------------
  [0,10)
@@ -1056,55 +1056,55 @@ SELECT uint2range(0::uint2, 65535::uint2);
 
 SELECT uint2range(0::uint2, 65535::uint2, '[]');
 ERROR:  uint2 out of range
-SELECT upper(uint2range(0, 10));
+SELECT upper(uint2range(0::uint2, 10::uint2));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(uint2range(0, 10));
+SELECT lower(uint2range(0::uint2, 10::uint2));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(uint2range(0, 10));
+SELECT isempty(uint2range(0::uint2, 10::uint2));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT uint2range(0, 10) @> 9::uint2;
+SELECT uint2range(0::uint2, 10::uint2) @> 9::uint2;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint2range(0, 10) @> 10::uint2;
+SELECT uint2range(0::uint2, 10::uint2) @> 10::uint2;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint2range(0, 10) && uint2range(10,20);
+SELECT uint2range(0::uint2, 10::uint2) && uint2range(10::uint2,20::uint2);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint2range(0, 10) && uint2range(9,20);
+SELECT uint2range(0::uint2, 10::uint2) && uint2range(9::uint2,20::uint2);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint2range(5, 10) - uint2range(5, 10);
+SELECT uint2range(5::uint2, 10::uint2) - uint2range(5::uint2, 10::uint2);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT uint2range(5, 10) - uint2range(5, 9);
+SELECT uint2range(5::uint2, 10::uint2) - uint2range(5::uint2, 9::uint2);
  ?column? 
 ----------
  [9,10)
@@ -1114,9 +1114,9 @@ CREATE TEMPORARY TABLE test_uint2range (
     r uint2range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_uint2range (r) VALUES (uint2range(0, 10));
-INSERT INTO test_uint2range (r) VALUES (uint2range(10, 20));
-INSERT INTO test_uint2range (r) VALUES (uint2range(19, 30));
+INSERT INTO test_uint2range (r) VALUES (uint2range(0::uint2, 10::uint2));
+INSERT INTO test_uint2range (r) VALUES (uint2range(10::uint2, 20::uint2));
+INSERT INTO test_uint2range (r) VALUES (uint2range(19::uint2, 30::uint2));
 ERROR:  conflicting key value violates exclusion constraint "test_uint2range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_uint2range;

--- a/expected/test_uint4.out
+++ b/expected/test_uint4.out
@@ -1042,7 +1042,7 @@ SELECT s FROM generate_series(1::uint4, 10::uint4, 2::uint4) s;
 (5 rows)
 
 -- Ranges block
-SELECT uint4range(0, 10);
+SELECT uint4range(0::uint4, 10::uint4);
  uint4range 
 ------------
  [0,10)
@@ -1056,55 +1056,55 @@ SELECT uint4range(0::uint4, 4294967295::uint4);
 
 SELECT uint4range(0::uint4, 4294967295::uint4, '[]');
 ERROR:  uint4 out of range
-SELECT upper(uint4range(0, 10));
+SELECT upper(uint4range(0::uint4, 10::uint4));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(uint4range(0, 10));
+SELECT lower(uint4range(0::uint4, 10::uint4));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(uint4range(0, 10));
+SELECT isempty(uint4range(0::uint4, 10::uint4));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT uint4range(0, 10) @> 9::uint4;
+SELECT uint4range(0::uint4, 10::uint4) @> 9::uint4;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint4range(0, 10) @> 10::uint4;
+SELECT uint4range(0::uint4, 10::uint4) @> 10::uint4;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint4range(0, 10) && uint4range(10,20);
+SELECT uint4range(0::uint4, 10::uint4) && uint4range(10::uint4,20::uint4);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint4range(0, 10) && uint4range(9,20);
+SELECT uint4range(0::uint4, 10::uint4) && uint4range(9::uint4,20::uint4);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint4range(5, 10) - uint4range(5, 10);
+SELECT uint4range(5::uint4, 10::uint4) - uint4range(5::uint4, 10::uint4);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT uint4range(5, 10) - uint4range(5, 9);
+SELECT uint4range(5::uint4, 10::uint4) - uint4range(5::uint4, 9::uint4);
  ?column? 
 ----------
  [9,10)
@@ -1114,9 +1114,9 @@ CREATE TEMPORARY TABLE test_uint4range (
     r uint4range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_uint4range (r) VALUES (uint4range(0, 10));
-INSERT INTO test_uint4range (r) VALUES (uint4range(10, 20));
-INSERT INTO test_uint4range (r) VALUES (uint4range(19, 30));
+INSERT INTO test_uint4range (r) VALUES (uint4range(0::uint4, 10::uint4));
+INSERT INTO test_uint4range (r) VALUES (uint4range(10::uint4, 20::uint4));
+INSERT INTO test_uint4range (r) VALUES (uint4range(19::uint4, 30::uint4));
 ERROR:  conflicting key value violates exclusion constraint "test_uint4range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_uint4range;

--- a/expected/test_uint8.out
+++ b/expected/test_uint8.out
@@ -1042,7 +1042,7 @@ SELECT s FROM generate_series(1::uint8, 10::uint8, 2::uint8) s;
 (5 rows)
 
 -- Ranges block
-SELECT uint8range(0, 10);
+SELECT uint8range(0::uint8, 10::uint8);
  uint8range 
 ------------
  [0,10)
@@ -1056,55 +1056,55 @@ SELECT uint8range(0::uint8, 18446744073709551615::uint8);
 
 SELECT uint8range(0::uint8, 18446744073709551615::uint8, '[]');
 ERROR:  uint8 out of range
-SELECT upper(uint8range(0, 10));
+SELECT upper(uint8range(0::uint8, 10::uint8));
  upper 
 -------
  10
 (1 row)
 
-SELECT lower(uint8range(0, 10));
+SELECT lower(uint8range(0::uint8, 10::uint8));
  lower 
 -------
  0
 (1 row)
 
-SELECT isempty(uint8range(0, 10));
+SELECT isempty(uint8range(0::uint8, 10::uint8));
  isempty 
 ---------
  f
 (1 row)
 
-SELECT uint8range(0, 10) @> 9::uint8;
+SELECT uint8range(0::uint8, 10::uint8) @> 9::uint8;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint8range(0, 10) @> 10::uint8;
+SELECT uint8range(0::uint8, 10::uint8) @> 10::uint8;
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint8range(0, 10) && uint8range(10,20);
+SELECT uint8range(0::uint8, 10::uint8) && uint8range(10::uint8,20::uint8);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT uint8range(0, 10) && uint8range(9,20);
+SELECT uint8range(0::uint8, 10::uint8) && uint8range(9::uint8,20::uint8);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT uint8range(5, 10) - uint8range(5, 10);
+SELECT uint8range(5::uint8, 10::uint8) - uint8range(5::uint8, 10::uint8);
  ?column? 
 ----------
  empty
 (1 row)
 
-SELECT uint8range(5, 10) - uint8range(5, 9);
+SELECT uint8range(5::uint8, 10::uint8) - uint8range(5::uint8, 9::uint8);
  ?column? 
 ----------
  [9,10)
@@ -1114,9 +1114,9 @@ CREATE TEMPORARY TABLE test_uint8range (
     r uint8range,
     EXCLUDE USING GIST (r WITH &&)
 );
-INSERT INTO test_uint8range (r) VALUES (uint8range(0, 10));
-INSERT INTO test_uint8range (r) VALUES (uint8range(10, 20));
-INSERT INTO test_uint8range (r) VALUES (uint8range(19, 30));
+INSERT INTO test_uint8range (r) VALUES (uint8range(0::uint8, 10::uint8));
+INSERT INTO test_uint8range (r) VALUES (uint8range(10::uint8, 20::uint8));
+INSERT INTO test_uint8range (r) VALUES (uint8range(19::uint8, 30::uint8));
 ERROR:  conflicting key value violates exclusion constraint "test_uint8range_r_excl"
 DETAIL:  Key (r)=([19,30)) conflicts with existing key (r)=([10,20)).
 DROP TABLE test_uint8range;

--- a/int_utils.h
+++ b/int_utils.h
@@ -44,6 +44,32 @@ static inline int8 DatumGetInt8(Datum X)
 #define PG_RETURN_INT8(x)	 return Int8GetDatum(x)
 #endif
 
+/*
+ * Macros for range-checking float values before converting to integer.
+ * We must be careful here that the boundary values are expressed exactly
+ * in the float domain.  PG_INTnn_MIN is an exact power of 2, so it will
+ * be represented exactly; but PG_INTnn_MAX isn't, and might get rounded
+ * off, so avoid using that.
+ * The input must be rounded to an integer beforehand, typically with rint(),
+ * else we might draw the wrong conclusion about close-to-the-limit values.
+ * These macros will do the right thing for Inf, but not necessarily for NaN,
+ * so check isnan(num) first if that's a possibility.
+ *
+ * Src: https://github.com/postgres/postgres/blob/9016fa7e3bcde8ae4c3d63c707143af147486a10/src/include/c.h#L1054
+ */
+
+#define FLOAT4_FITS_IN_INT8(num) \
+	((num) >= (float4) PG_INT8_MIN && (num) < -((float4) PG_INT8_MIN))
+
+#define FLOAT4_FITS_IN_INT128(num) \
+	((num) >= (float4) INT128_MIN && (num) < -((float4) INT128_MIN))
+
+#define FLOAT8_FITS_IN_INT8(num) \
+	((num) >= (float8) PG_INT8_MIN && (num) < -((float8) PG_INT8_MIN))
+
+#define FLOAT8_FITS_IN_INT128(num) \
+	((num) >= (float8) INT128_MIN && (num) < -((float8) INT128_MIN))
+
 typedef enum {
 	INT8_STRLEN = 4,
 	INT8_STRBUFLEN = INT8_STRLEN + 1,

--- a/sql/test_int1.sql
+++ b/sql/test_int1.sql
@@ -207,27 +207,27 @@ SELECT s FROM generate_series(1::int1, 10::int1, 2::int1) s;
 
 -- Ranges block
 
-SELECT int1range(0, 10);
+SELECT int1range(0::int1, 10::int1);
 SELECT int1range((-128)::int1, 127::int1);
 SELECT int1range((-128)::int1, 127::int1, '[]');
-SELECT upper(int1range(0, 10));
-SELECT lower(int1range(0, 10));
-SELECT isempty(int1range(0, 10));
-SELECT int1range(0, 10) @> 9::int1;
-SELECT int1range(0, 10) @> 10::int1;
-SELECT int1range(0, 10) && int1range(10,20);
-SELECT int1range(0, 10) && int1range(9,20);
-SELECT int1range(5, 10) - int1range(5, 10);
-SELECT int1range(5, 10) - int1range(5, 9);
+SELECT upper(int1range(0::int1, 10::int1));
+SELECT lower(int1range(0::int1, 10::int1));
+SELECT isempty(int1range(0::int1, 10::int1));
+SELECT int1range(0::int1, 10::int1) @> 9::int1;
+SELECT int1range(0::int1, 10::int1) @> 10::int1;
+SELECT int1range(0::int1, 10::int1) && int1range(10::int1,20::int1);
+SELECT int1range(0::int1, 10::int1) && int1range(9::int1,20::int1);
+SELECT int1range(5::int1, 10::int1) - int1range(5::int1, 10::int1);
+SELECT int1range(5::int1, 10::int1) - int1range(5::int1, 9::int1);
 CREATE TEMPORARY TABLE test_int1range (
     r int1range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_int1range (r) VALUES (int1range(0, 10));
-INSERT INTO test_int1range (r) VALUES (int1range(10, 20));
-INSERT INTO test_int1range (r) VALUES (int1range(19, 30));
+INSERT INTO test_int1range (r) VALUES (int1range(0::int1, 10::int1));
+INSERT INTO test_int1range (r) VALUES (int1range(10::int1, 20::int1));
+INSERT INTO test_int1range (r) VALUES (int1range(19::int1, 30::int1));
 
 DROP TABLE test_int1range;
 

--- a/sql/test_int16.sql
+++ b/sql/test_int16.sql
@@ -207,26 +207,26 @@ SELECT s FROM generate_series(1::int16, 10::int16, 2::int16) s;
 
 -- Ranges block
 
-SELECT int16range(0, 10);
+SELECT int16range(0::int16, 10::int16);
 SELECT int16range((-170141183460469231731687303715884105728)::int16, 170141183460469231731687303715884105727::int16);
 SELECT int16range((-170141183460469231731687303715884105728)::int16, 170141183460469231731687303715884105727::int16, '[]');
-SELECT upper(int16range(0, 10));
-SELECT lower(int16range(0, 10));
-SELECT isempty(int16range(0, 10));
-SELECT int16range(0, 10) @> 9::int16;
-SELECT int16range(0, 10) @> 10::int16;
-SELECT int16range(0, 10) && int16range(10,20);
-SELECT int16range(0, 10) && int16range(9,20);
-SELECT int16range(5, 10) - int16range(5, 10);
-SELECT int16range(5, 10) - int16range(5, 9);
+SELECT upper(int16range(0::int16, 10::int16));
+SELECT lower(int16range(0::int16, 10::int16));
+SELECT isempty(int16range(0::int16, 10::int16));
+SELECT int16range(0::int16, 10::int16) @> 9::int16;
+SELECT int16range(0::int16, 10::int16) @> 10::int16;
+SELECT int16range(0::int16, 10::int16) && int16range(10::int16,20::int16);
+SELECT int16range(0::int16, 10::int16) && int16range(9::int16,20::int16);
+SELECT int16range(5::int16, 10::int16) - int16range(5::int16, 10::int16);
+SELECT int16range(5::int16, 10::int16) - int16range(5::int16, 9::int16);
 CREATE TEMPORARY TABLE test_int16range (
     r int16range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_int16range (r) VALUES (int16range(0, 10));
-INSERT INTO test_int16range (r) VALUES (int16range(10, 20));
-INSERT INTO test_int16range (r) VALUES (int16range(19, 30));
+INSERT INTO test_int16range (r) VALUES (int16range(0::int16, 10::int16));
+INSERT INTO test_int16range (r) VALUES (int16range(10::int16, 20::int16));
+INSERT INTO test_int16range (r) VALUES (int16range(19::int16, 30::int16));
 
 DROP TABLE test_int16range;

--- a/sql/test_uint1.sql
+++ b/sql/test_uint1.sql
@@ -222,27 +222,27 @@ SELECT s FROM generate_series(1::uint1, 10::uint1, 2::uint1) s;
 
 -- Ranges block
 
-SELECT uint1range(0, 10);
+SELECT uint1range(0::uint1, 10::uint1);
 SELECT uint1range(0::uint1, 255::uint1);
 SELECT uint1range(0::uint1, 255::uint1, '[]');
-SELECT upper(uint1range(0, 10));
-SELECT lower(uint1range(0, 10));
-SELECT isempty(uint1range(0, 10));
-SELECT uint1range(0, 10) @> 9::uint1;
-SELECT uint1range(0, 10) @> 10::uint1;
-SELECT uint1range(0, 10) && uint1range(10,20);
-SELECT uint1range(0, 10) && uint1range(9,20);
-SELECT uint1range(5, 10) - uint1range(5, 10);
-SELECT uint1range(5, 10) - uint1range(5, 9);
+SELECT upper(uint1range(0::uint1, 10::uint1));
+SELECT lower(uint1range(0::uint1, 10::uint1));
+SELECT isempty(uint1range(0::uint1, 10::uint1));
+SELECT uint1range(0::uint1, 10::uint1) @> 9::uint1;
+SELECT uint1range(0::uint1, 10::uint1) @> 10::uint1;
+SELECT uint1range(0::uint1, 10::uint1) && uint1range(10::uint1,20::uint1);
+SELECT uint1range(0::uint1, 10::uint1) && uint1range(9::uint1,20::uint1);
+SELECT uint1range(5::uint1, 10::uint1) - uint1range(5::uint1, 10::uint1);
+SELECT uint1range(5::uint1, 10::uint1) - uint1range(5::uint1, 9::uint1);
 CREATE TEMPORARY TABLE test_uint1range (
     r uint1range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_uint1range (r) VALUES (uint1range(0, 10));
-INSERT INTO test_uint1range (r) VALUES (uint1range(10, 20));
-INSERT INTO test_uint1range (r) VALUES (uint1range(19, 30));
+INSERT INTO test_uint1range (r) VALUES (uint1range(0::uint1, 10::uint1));
+INSERT INTO test_uint1range (r) VALUES (uint1range(10::uint1, 20::uint1));
+INSERT INTO test_uint1range (r) VALUES (uint1range(19::uint1, 30::uint1));
 
 DROP TABLE test_uint1range;
 

--- a/sql/test_uint16.sql
+++ b/sql/test_uint16.sql
@@ -222,26 +222,26 @@ SELECT s FROM generate_series(1::uint16, 10::uint16, 2::uint16) s;
 
 -- Ranges block
 
-SELECT uint16range(0, 10);
+SELECT uint16range(0::uint16, 10::uint16);
 SELECT uint16range(0::uint16, 340282366920938463463374607431768211455::uint16);
 SELECT uint16range(0::uint16, 340282366920938463463374607431768211455::uint16, '[]');
-SELECT upper(uint16range(0, 10));
-SELECT lower(uint16range(0, 10));
-SELECT isempty(uint16range(0, 10));
-SELECT uint16range(0, 10) @> 9::uint16;
-SELECT uint16range(0, 10) @> 10::uint16;
-SELECT uint16range(0, 10) && uint16range(10,20);
-SELECT uint16range(0, 10) && uint16range(9,20);
-SELECT uint16range(5, 10) - uint16range(5, 10);
-SELECT uint16range(5, 10) - uint16range(5, 9);
+SELECT upper(uint16range(0::uint16, 10::uint16));
+SELECT lower(uint16range(0::uint16, 10::uint16));
+SELECT isempty(uint16range(0::uint16, 10::uint16));
+SELECT uint16range(0::uint16, 10::uint16) @> 9::uint16;
+SELECT uint16range(0::uint16, 10::uint16) @> 10::uint16;
+SELECT uint16range(0::uint16, 10::uint16) && uint16range(10::uint16,20::uint16);
+SELECT uint16range(0::uint16, 10::uint16) && uint16range(9::uint16,20::uint16);
+SELECT uint16range(5::uint16, 10::uint16) - uint16range(5::uint16, 10::uint16);
+SELECT uint16range(5::uint16, 10::uint16) - uint16range(5::uint16, 9::uint16);
 CREATE TEMPORARY TABLE test_uint16range (
     r uint16range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_uint16range (r) VALUES (uint16range(0, 10));
-INSERT INTO test_uint16range (r) VALUES (uint16range(10, 20));
-INSERT INTO test_uint16range (r) VALUES (uint16range(19, 30));
+INSERT INTO test_uint16range (r) VALUES (uint16range(0::uint16, 10::uint16));
+INSERT INTO test_uint16range (r) VALUES (uint16range(10::uint16, 20::uint16));
+INSERT INTO test_uint16range (r) VALUES (uint16range(19::uint16, 30::uint16));
 
 DROP TABLE test_uint16range;

--- a/sql/test_uint2.sql
+++ b/sql/test_uint2.sql
@@ -222,26 +222,26 @@ SELECT s FROM generate_series(1::uint2, 10::uint2, 2::uint2) s;
 
 -- Ranges block
 
-SELECT uint2range(0, 10);
+SELECT uint2range(0::uint2, 10::uint2);
 SELECT uint2range(0::uint2, 65535::uint2);
 SELECT uint2range(0::uint2, 65535::uint2, '[]');
-SELECT upper(uint2range(0, 10));
-SELECT lower(uint2range(0, 10));
-SELECT isempty(uint2range(0, 10));
-SELECT uint2range(0, 10) @> 9::uint2;
-SELECT uint2range(0, 10) @> 10::uint2;
-SELECT uint2range(0, 10) && uint2range(10,20);
-SELECT uint2range(0, 10) && uint2range(9,20);
-SELECT uint2range(5, 10) - uint2range(5, 10);
-SELECT uint2range(5, 10) - uint2range(5, 9);
+SELECT upper(uint2range(0::uint2, 10::uint2));
+SELECT lower(uint2range(0::uint2, 10::uint2));
+SELECT isempty(uint2range(0::uint2, 10::uint2));
+SELECT uint2range(0::uint2, 10::uint2) @> 9::uint2;
+SELECT uint2range(0::uint2, 10::uint2) @> 10::uint2;
+SELECT uint2range(0::uint2, 10::uint2) && uint2range(10::uint2,20::uint2);
+SELECT uint2range(0::uint2, 10::uint2) && uint2range(9::uint2,20::uint2);
+SELECT uint2range(5::uint2, 10::uint2) - uint2range(5::uint2, 10::uint2);
+SELECT uint2range(5::uint2, 10::uint2) - uint2range(5::uint2, 9::uint2);
 CREATE TEMPORARY TABLE test_uint2range (
     r uint2range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_uint2range (r) VALUES (uint2range(0, 10));
-INSERT INTO test_uint2range (r) VALUES (uint2range(10, 20));
-INSERT INTO test_uint2range (r) VALUES (uint2range(19, 30));
+INSERT INTO test_uint2range (r) VALUES (uint2range(0::uint2, 10::uint2));
+INSERT INTO test_uint2range (r) VALUES (uint2range(10::uint2, 20::uint2));
+INSERT INTO test_uint2range (r) VALUES (uint2range(19::uint2, 30::uint2));
 
 DROP TABLE test_uint2range;

--- a/sql/test_uint4.sql
+++ b/sql/test_uint4.sql
@@ -222,26 +222,26 @@ SELECT s FROM generate_series(1::uint4, 10::uint4, 2::uint4) s;
 
 -- Ranges block
 
-SELECT uint4range(0, 10);
+SELECT uint4range(0::uint4, 10::uint4);
 SELECT uint4range(0::uint4, 4294967295::uint4);
 SELECT uint4range(0::uint4, 4294967295::uint4, '[]');
-SELECT upper(uint4range(0, 10));
-SELECT lower(uint4range(0, 10));
-SELECT isempty(uint4range(0, 10));
-SELECT uint4range(0, 10) @> 9::uint4;
-SELECT uint4range(0, 10) @> 10::uint4;
-SELECT uint4range(0, 10) && uint4range(10,20);
-SELECT uint4range(0, 10) && uint4range(9,20);
-SELECT uint4range(5, 10) - uint4range(5, 10);
-SELECT uint4range(5, 10) - uint4range(5, 9);
+SELECT upper(uint4range(0::uint4, 10::uint4));
+SELECT lower(uint4range(0::uint4, 10::uint4));
+SELECT isempty(uint4range(0::uint4, 10::uint4));
+SELECT uint4range(0::uint4, 10::uint4) @> 9::uint4;
+SELECT uint4range(0::uint4, 10::uint4) @> 10::uint4;
+SELECT uint4range(0::uint4, 10::uint4) && uint4range(10::uint4,20::uint4);
+SELECT uint4range(0::uint4, 10::uint4) && uint4range(9::uint4,20::uint4);
+SELECT uint4range(5::uint4, 10::uint4) - uint4range(5::uint4, 10::uint4);
+SELECT uint4range(5::uint4, 10::uint4) - uint4range(5::uint4, 9::uint4);
 CREATE TEMPORARY TABLE test_uint4range (
     r uint4range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_uint4range (r) VALUES (uint4range(0, 10));
-INSERT INTO test_uint4range (r) VALUES (uint4range(10, 20));
-INSERT INTO test_uint4range (r) VALUES (uint4range(19, 30));
+INSERT INTO test_uint4range (r) VALUES (uint4range(0::uint4, 10::uint4));
+INSERT INTO test_uint4range (r) VALUES (uint4range(10::uint4, 20::uint4));
+INSERT INTO test_uint4range (r) VALUES (uint4range(19::uint4, 30::uint4));
 
 DROP TABLE test_uint4range;

--- a/sql/test_uint8.sql
+++ b/sql/test_uint8.sql
@@ -222,26 +222,26 @@ SELECT s FROM generate_series(1::uint8, 10::uint8, 2::uint8) s;
 
 -- Ranges block
 
-SELECT uint8range(0, 10);
+SELECT uint8range(0::uint8, 10::uint8);
 SELECT uint8range(0::uint8, 18446744073709551615::uint8);
 SELECT uint8range(0::uint8, 18446744073709551615::uint8, '[]');
-SELECT upper(uint8range(0, 10));
-SELECT lower(uint8range(0, 10));
-SELECT isempty(uint8range(0, 10));
-SELECT uint8range(0, 10) @> 9::uint8;
-SELECT uint8range(0, 10) @> 10::uint8;
-SELECT uint8range(0, 10) && uint8range(10,20);
-SELECT uint8range(0, 10) && uint8range(9,20);
-SELECT uint8range(5, 10) - uint8range(5, 10);
-SELECT uint8range(5, 10) - uint8range(5, 9);
+SELECT upper(uint8range(0::uint8, 10::uint8));
+SELECT lower(uint8range(0::uint8, 10::uint8));
+SELECT isempty(uint8range(0::uint8, 10::uint8));
+SELECT uint8range(0::uint8, 10::uint8) @> 9::uint8;
+SELECT uint8range(0::uint8, 10::uint8) @> 10::uint8;
+SELECT uint8range(0::uint8, 10::uint8) && uint8range(10::uint8,20::uint8);
+SELECT uint8range(0::uint8, 10::uint8) && uint8range(9::uint8,20::uint8);
+SELECT uint8range(5::uint8, 10::uint8) - uint8range(5::uint8, 10::uint8);
+SELECT uint8range(5::uint8, 10::uint8) - uint8range(5::uint8, 9::uint8);
 CREATE TEMPORARY TABLE test_uint8range (
     r uint8range,
 
     EXCLUDE USING GIST (r WITH &&)
 );
 
-INSERT INTO test_uint8range (r) VALUES (uint8range(0, 10));
-INSERT INTO test_uint8range (r) VALUES (uint8range(10, 20));
-INSERT INTO test_uint8range (r) VALUES (uint8range(19, 30));
+INSERT INTO test_uint8range (r) VALUES (uint8range(0::uint8, 10::uint8));
+INSERT INTO test_uint8range (r) VALUES (uint8range(10::uint8, 20::uint8));
+INSERT INTO test_uint8range (r) VALUES (uint8range(19::uint8, 30::uint8));
 
 DROP TABLE test_uint8range;

--- a/uint128--1.0.0.sql
+++ b/uint128--1.0.0.sql
@@ -45,7 +45,7 @@ CREATE TYPE uint16 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint16) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint16 AS double precision) WITH INOUT AS IMPLICIT;
@@ -1809,7 +1809,7 @@ CREATE TYPE uint8 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint8) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint8 AS double precision) WITH INOUT AS IMPLICIT;
@@ -3557,7 +3557,7 @@ CREATE TYPE uint4 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint4) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint4 AS double precision) WITH INOUT AS IMPLICIT;
@@ -5305,7 +5305,7 @@ CREATE TYPE uint2 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint2) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint2 AS double precision) WITH INOUT AS IMPLICIT;
@@ -7053,7 +7053,7 @@ CREATE TYPE int16 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS int16) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (int16 AS double precision) WITH INOUT AS IMPLICIT;
@@ -8763,6 +8763,8 @@ CREATE TYPE int16range AS RANGE (
 
 
 -- Cross types ops
+-- Type uint16 block
+
 
 -- Casts block
 
@@ -9572,6 +9574,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint8 block
+
 
 -- Casts block
 
@@ -10365,6 +10369,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint4 block
+
 
 -- Casts block
 
@@ -11142,6 +11148,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint2 block
+
 
 -- Casts block
 
@@ -11902,6 +11910,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type int16 block
 
 
 -- Casts block

--- a/uint128--1.0.1--1.1.0.sql
+++ b/uint128--1.0.1--1.1.0.sql
@@ -41,7 +41,7 @@ CREATE TYPE uint1 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint1) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint1 AS double precision) WITH INOUT AS IMPLICIT;
@@ -1789,7 +1789,7 @@ CREATE TYPE int1 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS int1) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (int1 AS double precision) WITH INOUT AS IMPLICIT;
@@ -3499,6 +3499,8 @@ CREATE TYPE int1range AS RANGE (
 
 
 -- Cross types ops
+-- Type uint1 block
+
 
 -- Casts block
 
@@ -4698,6 +4700,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type int1 block
+
 
 -- Casts block
 
@@ -5881,6 +5885,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint16 block
+
 
 -- Casts block
 -- Ops block
@@ -6267,6 +6273,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type uint8 block
 
 
 -- Casts block
@@ -6655,6 +6663,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint4 block
+
 
 -- Casts block
 -- Ops block
@@ -7042,6 +7052,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint2 block
+
 
 -- Casts block
 -- Ops block
@@ -7428,6 +7440,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type int16 block
 
 
 -- Casts block

--- a/uint128--1.1.0--1.1.1.sql
+++ b/uint128--1.1.0--1.1.1.sql
@@ -1,3 +1,5 @@
+-- Type uint1 block
+
 
 -- Casts block
 
@@ -55,6 +57,8 @@ CREATE CAST (numeric AS uint1) WITH FUNCTION uint1_from_numeric(numeric) AS ASSI
 
 DROP CAST (uint1 AS numeric);
 CREATE CAST (uint1 AS numeric) WITH FUNCTION uint1_to_numeric(uint1) AS IMPLICIT;
+-- Type uint2 block
+
 
 -- Casts block
 
@@ -112,6 +116,8 @@ CREATE CAST (numeric AS uint2) WITH FUNCTION uint2_from_numeric(numeric) AS ASSI
 
 DROP CAST (uint2 AS numeric);
 CREATE CAST (uint2 AS numeric) WITH FUNCTION uint2_to_numeric(uint2) AS IMPLICIT;
+-- Type uint4 block
+
 
 -- Casts block
 
@@ -169,6 +175,8 @@ CREATE CAST (numeric AS uint4) WITH FUNCTION uint4_from_numeric(numeric) AS ASSI
 
 DROP CAST (uint4 AS numeric);
 CREATE CAST (uint4 AS numeric) WITH FUNCTION uint4_to_numeric(uint4) AS IMPLICIT;
+-- Type uint8 block
+
 
 -- Casts block
 
@@ -207,6 +215,8 @@ CREATE CAST (uint8 AS jsonb) WITH FUNCTION uint8_to_jsonb(uint8) AS IMPLICIT;
 
 
 
+-- Type uint16 block
+
 
 -- Casts block
 
@@ -244,6 +254,8 @@ CREATE CAST (uint16 AS jsonb) WITH FUNCTION uint16_to_jsonb(uint16) AS IMPLICIT;
 -- Ops block
 
 
+
+-- Type int1 block
 
 
 -- Casts block
@@ -302,6 +314,8 @@ CREATE CAST (numeric AS int1) WITH FUNCTION int1_from_numeric(numeric) AS ASSIGN
 
 DROP CAST (int1 AS numeric);
 CREATE CAST (int1 AS numeric) WITH FUNCTION int1_to_numeric(int1) AS IMPLICIT;
+-- Type int16 block
+
 
 -- Casts block
 

--- a/uint128--1.1.0.sql
+++ b/uint128--1.1.0.sql
@@ -45,7 +45,7 @@ CREATE TYPE uint16 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint16) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint16 AS double precision) WITH INOUT AS IMPLICIT;
@@ -1809,7 +1809,7 @@ CREATE TYPE uint8 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint8) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint8 AS double precision) WITH INOUT AS IMPLICIT;
@@ -3557,7 +3557,7 @@ CREATE TYPE uint4 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint4) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint4 AS double precision) WITH INOUT AS IMPLICIT;
@@ -5305,7 +5305,7 @@ CREATE TYPE uint2 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint2) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint2 AS double precision) WITH INOUT AS IMPLICIT;
@@ -7053,7 +7053,7 @@ CREATE TYPE int16 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS int16) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (int16 AS double precision) WITH INOUT AS IMPLICIT;
@@ -8763,6 +8763,8 @@ CREATE TYPE int16range AS RANGE (
 
 
 -- Cross types ops
+-- Type uint16 block
+
 
 -- Casts block
 
@@ -9572,6 +9574,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint8 block
+
 
 -- Casts block
 
@@ -10365,6 +10369,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint4 block
+
 
 -- Casts block
 
@@ -11142,6 +11148,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint2 block
+
 
 -- Casts block
 
@@ -11902,6 +11910,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type int16 block
 
 
 -- Casts block
@@ -12695,7 +12705,7 @@ CREATE TYPE uint1 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint1) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint1 AS double precision) WITH INOUT AS IMPLICIT;
@@ -14443,7 +14453,7 @@ CREATE TYPE int1 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS int1) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (int1 AS double precision) WITH INOUT AS IMPLICIT;
@@ -16153,6 +16163,8 @@ CREATE TYPE int1range AS RANGE (
 
 
 -- Cross types ops
+-- Type uint1 block
+
 
 -- Casts block
 
@@ -17352,6 +17364,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type int1 block
+
 
 -- Casts block
 
@@ -18535,6 +18549,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint16 block
+
 
 -- Casts block
 -- Ops block
@@ -18921,6 +18937,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type uint8 block
 
 
 -- Casts block
@@ -19309,6 +19327,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint4 block
+
 
 -- Casts block
 -- Ops block
@@ -19696,6 +19716,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint2 block
+
 
 -- Casts block
 -- Ops block
@@ -20082,6 +20104,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type int16 block
 
 
 -- Casts block

--- a/uint128--1.1.1--1.2.0.sql
+++ b/uint128--1.1.1--1.2.0.sql
@@ -1,3 +1,1178 @@
+-- Type uint1 block
+
+-- Cast functions uint1 block
+
+CREATE OR REPLACE FUNCTION uint1_from_int1(int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int1';
+
+CREATE OR REPLACE FUNCTION uint1_from_int2(int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int2';
+
+CREATE OR REPLACE FUNCTION uint1_from_int4(int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int4';
+
+CREATE OR REPLACE FUNCTION uint1_from_int8(int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int8';
+
+CREATE OR REPLACE FUNCTION uint1_from_int16(int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int16';
+
+CREATE OR REPLACE FUNCTION uint1_from_uint2(uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint2';
+
+CREATE OR REPLACE FUNCTION uint1_from_uint4(uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint4';
+
+CREATE OR REPLACE FUNCTION uint1_from_uint8(uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint8';
+
+CREATE OR REPLACE FUNCTION uint1_from_uint16(uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint16';
+
+CREATE OR REPLACE FUNCTION uint1_from_numeric(numeric) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_numeric';
+
+CREATE OR REPLACE FUNCTION uint1_from_float4(float4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_float4';
+
+CREATE OR REPLACE FUNCTION uint1_from_float8(float8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_float8';
+
+CREATE OR REPLACE FUNCTION uint1_from_json(json) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_json';
+
+CREATE OR REPLACE FUNCTION uint1_from_jsonb(jsonb) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_jsonb';
+
+-- Type uint2 block
+
+-- Cast functions uint2 block
+
+CREATE OR REPLACE FUNCTION uint2_from_int1(int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int1';
+
+CREATE OR REPLACE FUNCTION uint2_from_int2(int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int2';
+
+CREATE OR REPLACE FUNCTION uint2_from_int4(int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int4';
+
+CREATE OR REPLACE FUNCTION uint2_from_int8(int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int8';
+
+CREATE OR REPLACE FUNCTION uint2_from_int16(int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int16';
+
+CREATE OR REPLACE FUNCTION uint2_from_uint1(uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint1';
+
+CREATE OR REPLACE FUNCTION uint2_from_uint4(uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint4';
+
+CREATE OR REPLACE FUNCTION uint2_from_uint8(uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint8';
+
+CREATE OR REPLACE FUNCTION uint2_from_uint16(uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint16';
+
+CREATE OR REPLACE FUNCTION uint2_from_numeric(numeric) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_numeric';
+
+CREATE OR REPLACE FUNCTION uint2_from_float4(float4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_float4';
+
+CREATE OR REPLACE FUNCTION uint2_from_float8(float8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_float8';
+
+CREATE OR REPLACE FUNCTION uint2_from_json(json) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_json';
+
+CREATE OR REPLACE FUNCTION uint2_from_jsonb(jsonb) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_jsonb';
+
+-- Type uint4 block
+
+-- Cast functions uint4 block
+
+CREATE OR REPLACE FUNCTION uint4_from_int1(int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int1';
+
+CREATE OR REPLACE FUNCTION uint4_from_int2(int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int2';
+
+CREATE OR REPLACE FUNCTION uint4_from_int4(int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int4';
+
+CREATE OR REPLACE FUNCTION uint4_from_int8(int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int8';
+
+CREATE OR REPLACE FUNCTION uint4_from_int16(int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int16';
+
+CREATE OR REPLACE FUNCTION uint4_from_uint1(uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint1';
+
+CREATE OR REPLACE FUNCTION uint4_from_uint2(uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint2';
+
+CREATE OR REPLACE FUNCTION uint4_from_uint8(uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint8';
+
+CREATE OR REPLACE FUNCTION uint4_from_uint16(uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint16';
+
+CREATE OR REPLACE FUNCTION uint4_from_numeric(numeric) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_numeric';
+
+CREATE OR REPLACE FUNCTION uint4_from_float4(float4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_float4';
+
+CREATE OR REPLACE FUNCTION uint4_from_float8(float8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_float8';
+
+CREATE OR REPLACE FUNCTION uint4_from_json(json) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_json';
+
+CREATE OR REPLACE FUNCTION uint4_from_jsonb(jsonb) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_jsonb';
+
+-- Type uint8 block
+
+-- Cast functions uint8 block
+
+CREATE OR REPLACE FUNCTION uint8_from_int1(int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int1';
+
+CREATE OR REPLACE FUNCTION uint8_from_int2(int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int2';
+
+CREATE OR REPLACE FUNCTION uint8_from_int4(int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int4';
+
+CREATE OR REPLACE FUNCTION uint8_from_int8(int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int8';
+
+CREATE OR REPLACE FUNCTION uint8_from_int16(int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int16';
+
+CREATE OR REPLACE FUNCTION uint8_from_uint1(uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint1';
+
+CREATE OR REPLACE FUNCTION uint8_from_uint2(uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint2';
+
+CREATE OR REPLACE FUNCTION uint8_from_uint4(uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint4';
+
+CREATE OR REPLACE FUNCTION uint8_from_uint16(uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint16';
+
+CREATE OR REPLACE FUNCTION uint8_from_float4(float4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_float4';
+
+CREATE OR REPLACE FUNCTION uint8_from_float8(float8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_float8';
+
+CREATE OR REPLACE FUNCTION uint8_from_json(json) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_json';
+
+CREATE OR REPLACE FUNCTION uint8_from_jsonb(jsonb) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_jsonb';
+
+-- Type uint16 block
+
+-- Cast functions uint16 block
+
+CREATE OR REPLACE FUNCTION uint16_from_int1(int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int1';
+
+CREATE OR REPLACE FUNCTION uint16_from_int2(int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int2';
+
+CREATE OR REPLACE FUNCTION uint16_from_int4(int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int4';
+
+CREATE OR REPLACE FUNCTION uint16_from_int8(int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int8';
+
+CREATE OR REPLACE FUNCTION uint16_from_int16(int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int16';
+
+CREATE OR REPLACE FUNCTION uint16_from_uint1(uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint1';
+
+CREATE OR REPLACE FUNCTION uint16_from_uint2(uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint2';
+
+CREATE OR REPLACE FUNCTION uint16_from_uint4(uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint4';
+
+CREATE OR REPLACE FUNCTION uint16_from_uint8(uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint8';
+
+CREATE OR REPLACE FUNCTION uint16_from_float4(float4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_float4';
+
+CREATE OR REPLACE FUNCTION uint16_from_float8(float8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_float8';
+
+CREATE OR REPLACE FUNCTION uint16_from_json(json) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_json';
+
+CREATE OR REPLACE FUNCTION uint16_from_jsonb(jsonb) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_jsonb';
+
+CREATE OR REPLACE FUNCTION uint16_from_uuid(uuid) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uuid';
+
+-- Type int1 block
+
+-- Cast functions int1 block
+
+CREATE OR REPLACE FUNCTION int1_from_uint1(uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint1';
+
+CREATE OR REPLACE FUNCTION int1_from_uint2(uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint2';
+
+CREATE OR REPLACE FUNCTION int1_from_uint4(uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint4';
+
+CREATE OR REPLACE FUNCTION int1_from_uint8(uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint8';
+
+CREATE OR REPLACE FUNCTION int1_from_uint16(uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint16';
+
+CREATE OR REPLACE FUNCTION int1_from_int2(int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int2';
+
+CREATE OR REPLACE FUNCTION int1_from_int4(int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int4';
+
+CREATE OR REPLACE FUNCTION int1_from_int8(int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int8';
+
+CREATE OR REPLACE FUNCTION int1_from_int16(int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int16';
+
+CREATE OR REPLACE FUNCTION int1_from_numeric(numeric) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_numeric';
+
+CREATE OR REPLACE FUNCTION int1_from_float4(float4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_float4';
+
+CREATE OR REPLACE FUNCTION int1_from_float8(float8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_float8';
+
+CREATE OR REPLACE FUNCTION int1_from_json(json) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_json';
+
+CREATE OR REPLACE FUNCTION int1_from_jsonb(jsonb) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_jsonb';
+
+-- Type int2 block
+
+-- Cast functions int2 block
+
+CREATE OR REPLACE FUNCTION int2_from_uint1(uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint1';
+
+CREATE OR REPLACE FUNCTION int2_from_uint2(uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint2';
+
+CREATE OR REPLACE FUNCTION int2_from_uint4(uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint4';
+
+CREATE OR REPLACE FUNCTION int2_from_uint8(uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint8';
+
+CREATE OR REPLACE FUNCTION int2_from_uint16(uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint16';
+
+CREATE OR REPLACE FUNCTION int2_from_int1(int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_int1';
+
+CREATE OR REPLACE FUNCTION int2_from_int16(int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_int16';
+
+-- Type int4 block
+
+-- Cast functions int4 block
+
+CREATE OR REPLACE FUNCTION int4_from_uint1(uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint1';
+
+CREATE OR REPLACE FUNCTION int4_from_uint2(uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint2';
+
+CREATE OR REPLACE FUNCTION int4_from_uint4(uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint4';
+
+CREATE OR REPLACE FUNCTION int4_from_uint8(uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint8';
+
+CREATE OR REPLACE FUNCTION int4_from_uint16(uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint16';
+
+CREATE OR REPLACE FUNCTION int4_from_int1(int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_int1';
+
+CREATE OR REPLACE FUNCTION int4_from_int16(int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_int16';
+
+-- Type int8 block
+
+-- Cast functions int8 block
+
+CREATE OR REPLACE FUNCTION int8_from_uint1(uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint1';
+
+CREATE OR REPLACE FUNCTION int8_from_uint2(uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint2';
+
+CREATE OR REPLACE FUNCTION int8_from_uint4(uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint4';
+
+CREATE OR REPLACE FUNCTION int8_from_uint8(uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint8';
+
+CREATE OR REPLACE FUNCTION int8_from_uint16(uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint16';
+
+CREATE OR REPLACE FUNCTION int8_from_int1(int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_int1';
+
+CREATE OR REPLACE FUNCTION int8_from_int16(int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_int16';
+
+-- Type int16 block
+
+-- Cast functions int16 block
+
+CREATE OR REPLACE FUNCTION int16_from_uint1(uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint1';
+
+CREATE OR REPLACE FUNCTION int16_from_uint2(uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint2';
+
+CREATE OR REPLACE FUNCTION int16_from_uint4(uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint4';
+
+CREATE OR REPLACE FUNCTION int16_from_uint8(uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint8';
+
+CREATE OR REPLACE FUNCTION int16_from_uint16(uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint16';
+
+CREATE OR REPLACE FUNCTION int16_from_int1(int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int1';
+
+CREATE OR REPLACE FUNCTION int16_from_int2(int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int2';
+
+CREATE OR REPLACE FUNCTION int16_from_int4(int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int4';
+
+CREATE OR REPLACE FUNCTION int16_from_int8(int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int8';
+
+CREATE OR REPLACE FUNCTION int16_from_float4(float4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_float4';
+
+CREATE OR REPLACE FUNCTION int16_from_float8(float8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_float8';
+
+CREATE OR REPLACE FUNCTION int16_from_json(json) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_json';
+
+CREATE OR REPLACE FUNCTION int16_from_jsonb(jsonb) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_jsonb';
+
+-- Type numeric block
+
+-- Cast functions numeric block
+
+CREATE OR REPLACE FUNCTION numeric_from_uint1(uint1) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint1';
+
+CREATE OR REPLACE FUNCTION numeric_from_uint2(uint2) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint2';
+
+CREATE OR REPLACE FUNCTION numeric_from_uint4(uint4) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint4';
+
+CREATE OR REPLACE FUNCTION numeric_from_int1(int1) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_int1';
+
+-- Type float4 block
+
+-- Cast functions float4 block
+
+CREATE OR REPLACE FUNCTION float4_from_uint1(uint1) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint1';
+
+CREATE OR REPLACE FUNCTION float4_from_uint2(uint2) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint2';
+
+CREATE OR REPLACE FUNCTION float4_from_uint4(uint4) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint4';
+
+CREATE OR REPLACE FUNCTION float4_from_uint8(uint8) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint8';
+
+CREATE OR REPLACE FUNCTION float4_from_uint16(uint16) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint16';
+
+CREATE OR REPLACE FUNCTION float4_from_int1(int1) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_int1';
+
+CREATE OR REPLACE FUNCTION float4_from_int16(int16) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_int16';
+
+-- Type float8 block
+
+-- Cast functions float8 block
+
+CREATE OR REPLACE FUNCTION float8_from_uint1(uint1) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint1';
+
+CREATE OR REPLACE FUNCTION float8_from_uint2(uint2) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint2';
+
+CREATE OR REPLACE FUNCTION float8_from_uint4(uint4) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint4';
+
+CREATE OR REPLACE FUNCTION float8_from_uint8(uint8) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint8';
+
+CREATE OR REPLACE FUNCTION float8_from_uint16(uint16) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint16';
+
+CREATE OR REPLACE FUNCTION float8_from_int1(int1) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_int1';
+
+CREATE OR REPLACE FUNCTION float8_from_int16(int16) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_int16';
+
+-- Type json block
+
+-- Cast functions json block
+
+CREATE OR REPLACE FUNCTION json_from_uint1(uint1) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint1';
+
+CREATE OR REPLACE FUNCTION json_from_uint2(uint2) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint2';
+
+CREATE OR REPLACE FUNCTION json_from_uint4(uint4) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint4';
+
+CREATE OR REPLACE FUNCTION json_from_uint8(uint8) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint8';
+
+CREATE OR REPLACE FUNCTION json_from_uint16(uint16) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint16';
+
+CREATE OR REPLACE FUNCTION json_from_int1(int1) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_int1';
+
+CREATE OR REPLACE FUNCTION json_from_int16(int16) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_int16';
+
+-- Type jsonb block
+
+-- Cast functions jsonb block
+
+CREATE OR REPLACE FUNCTION jsonb_from_uint1(uint1) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint1';
+
+CREATE OR REPLACE FUNCTION jsonb_from_uint2(uint2) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint2';
+
+CREATE OR REPLACE FUNCTION jsonb_from_uint4(uint4) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint4';
+
+CREATE OR REPLACE FUNCTION jsonb_from_uint8(uint8) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint8';
+
+CREATE OR REPLACE FUNCTION jsonb_from_uint16(uint16) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint16';
+
+CREATE OR REPLACE FUNCTION jsonb_from_int1(int1) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_int1';
+
+CREATE OR REPLACE FUNCTION jsonb_from_int16(int16) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_int16';
+
+-- Type uuid block
+
+-- Cast functions uuid block
+
+CREATE OR REPLACE FUNCTION uuid_from_uint16(uint16) RETURNS uuid
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uuid_from_uint16';
+
 -- Cleanup old casts 
 
 DO $$
@@ -19,1200 +1194,17 @@ BEGIN
         WHERE
             d.deptype = 'e'
             AND e.extname = 'uint128'
-            AND (p.castsource, p.casttarget) NOT IN (
-                ('int16'::regtype, 'numeric'::regtype),
-                ('numeric'::regtype, 'int16'::regtype),
-                ('uint16'::regtype, 'numeric'::regtype),
-                ('numeric'::regtype, 'uint16'::regtype),
-                ('uint8'::regtype, 'numeric'::regtype),
-                ('numeric'::regtype, 'uint8'::regtype)
-            )
         ORDER BY 3, 4
     LOOP
         RAISE NOTICE 'Dropping cast (% -> %)', r.castsource::regtype, r.casttarget::regtype;
-        EXECUTE format('DROP CAST (%I AS %I)', r.castsource::regtype, r.casttarget::regtype);
+        EXECUTE format('DROP CAST (%s AS %s)', r.castsource::regtype, r.casttarget::regtype);
 
-        IF r.castfunc IS NOT NULL AND r.castfunc > 0 THEN
-            RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
-            EXECUTE format('DROP FUNCTION %I', r.castfunc::regprocedure);
-        END IF;
+--         IF r.castfunc IS NOT NULL AND r.castfunc > 0 THEN
+--             RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
+--             EXECUTE format('DROP FUNCTION %s', r.castfunc::regprocedure);
+--         END IF;
     END LOOP;
 END $$;
-
--- Type uint1 block
-
--- Cast functions uint1 block
-
-CREATE FUNCTION uint1_from_int1(int1) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_int1';
-
-CREATE FUNCTION uint1_from_int2(int2) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_int2';
-
-CREATE FUNCTION uint1_from_int4(int4) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_int4';
-
-CREATE FUNCTION uint1_from_int8(int8) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_int8';
-
-CREATE FUNCTION uint1_from_int16(int16) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_int16';
-
-CREATE FUNCTION uint1_from_uint2(uint2) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_uint2';
-
-CREATE FUNCTION uint1_from_uint4(uint4) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_uint4';
-
-CREATE FUNCTION uint1_from_uint8(uint8) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_uint8';
-
-CREATE FUNCTION uint1_from_uint16(uint16) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_uint16';
-
-CREATE FUNCTION uint1_from_numeric(numeric) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_numeric';
-
-CREATE FUNCTION uint1_from_float4(float4) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_float4';
-
-CREATE FUNCTION uint1_from_float8(float8) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_float8';
-
-CREATE FUNCTION uint1_from_json(json) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_json';
-
-CREATE FUNCTION uint1_from_jsonb(jsonb) RETURNS uint1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint1_from_jsonb';
-
--- Type uint2 block
-
--- Cast functions uint2 block
-
-CREATE FUNCTION uint2_from_int1(int1) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_int1';
-
-CREATE FUNCTION uint2_from_int2(int2) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_int2';
-
-CREATE FUNCTION uint2_from_int4(int4) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_int4';
-
-CREATE FUNCTION uint2_from_int8(int8) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_int8';
-
-CREATE FUNCTION uint2_from_int16(int16) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_int16';
-
-CREATE FUNCTION uint2_from_uint1(uint1) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_uint1';
-
-CREATE FUNCTION uint2_from_uint4(uint4) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_uint4';
-
-CREATE FUNCTION uint2_from_uint8(uint8) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_uint8';
-
-CREATE FUNCTION uint2_from_uint16(uint16) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_uint16';
-
-CREATE FUNCTION uint2_from_numeric(numeric) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_numeric';
-
-CREATE FUNCTION uint2_from_float4(float4) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_float4';
-
-CREATE FUNCTION uint2_from_float8(float8) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_float8';
-
-CREATE FUNCTION uint2_from_json(json) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_json';
-
-CREATE FUNCTION uint2_from_jsonb(jsonb) RETURNS uint2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint2_from_jsonb';
-
--- Type uint4 block
-
--- Cast functions uint4 block
-
-CREATE FUNCTION uint4_from_int1(int1) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_int1';
-
-CREATE FUNCTION uint4_from_int2(int2) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_int2';
-
-CREATE FUNCTION uint4_from_int4(int4) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_int4';
-
-CREATE FUNCTION uint4_from_int8(int8) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_int8';
-
-CREATE FUNCTION uint4_from_int16(int16) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_int16';
-
-CREATE FUNCTION uint4_from_uint1(uint1) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_uint1';
-
-CREATE FUNCTION uint4_from_uint2(uint2) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_uint2';
-
-CREATE FUNCTION uint4_from_uint8(uint8) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_uint8';
-
-CREATE FUNCTION uint4_from_uint16(uint16) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_uint16';
-
-CREATE FUNCTION uint4_from_numeric(numeric) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_numeric';
-
-CREATE FUNCTION uint4_from_float4(float4) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_float4';
-
-CREATE FUNCTION uint4_from_float8(float8) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_float8';
-
-CREATE FUNCTION uint4_from_json(json) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_json';
-
-CREATE FUNCTION uint4_from_jsonb(jsonb) RETURNS uint4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint4_from_jsonb';
-
--- Type uint8 block
-
--- Cast functions uint8 block
-
-CREATE FUNCTION uint8_from_int1(int1) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_int1';
-
-CREATE FUNCTION uint8_from_int2(int2) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_int2';
-
-CREATE FUNCTION uint8_from_int4(int4) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_int4';
-
-CREATE FUNCTION uint8_from_int8(int8) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_int8';
-
-CREATE FUNCTION uint8_from_int16(int16) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_int16';
-
-CREATE FUNCTION uint8_from_uint1(uint1) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_uint1';
-
-CREATE FUNCTION uint8_from_uint2(uint2) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_uint2';
-
-CREATE FUNCTION uint8_from_uint4(uint4) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_uint4';
-
-CREATE FUNCTION uint8_from_uint16(uint16) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_uint16';
-
-CREATE FUNCTION uint8_from_float4(float4) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_float4';
-
-CREATE FUNCTION uint8_from_float8(float8) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_float8';
-
-CREATE FUNCTION uint8_from_json(json) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_json';
-
-CREATE FUNCTION uint8_from_jsonb(jsonb) RETURNS uint8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint8_from_jsonb';
-
--- Type uint16 block
-
--- Cast functions uint16 block
-
-CREATE FUNCTION uint16_from_int1(int1) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_int1';
-
-CREATE FUNCTION uint16_from_int2(int2) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_int2';
-
-CREATE FUNCTION uint16_from_int4(int4) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_int4';
-
-CREATE FUNCTION uint16_from_int8(int8) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_int8';
-
-CREATE FUNCTION uint16_from_int16(int16) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_int16';
-
-CREATE FUNCTION uint16_from_uint1(uint1) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_uint1';
-
-CREATE FUNCTION uint16_from_uint2(uint2) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_uint2';
-
-CREATE FUNCTION uint16_from_uint4(uint4) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_uint4';
-
-CREATE FUNCTION uint16_from_uint8(uint8) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_uint8';
-
-CREATE FUNCTION uint16_from_float4(float4) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_float4';
-
-CREATE FUNCTION uint16_from_float8(float8) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_float8';
-
-CREATE FUNCTION uint16_from_json(json) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_json';
-
-CREATE FUNCTION uint16_from_jsonb(jsonb) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_jsonb';
-
-CREATE FUNCTION uint16_from_uuid(uuid) RETURNS uint16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uint16_from_uuid';
-
--- Type int1 block
-
--- Cast functions int1 block
-
-CREATE FUNCTION int1_from_uint1(uint1) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_uint1';
-
-CREATE FUNCTION int1_from_uint2(uint2) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_uint2';
-
-CREATE FUNCTION int1_from_uint4(uint4) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_uint4';
-
-CREATE FUNCTION int1_from_uint8(uint8) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_uint8';
-
-CREATE FUNCTION int1_from_uint16(uint16) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_uint16';
-
-CREATE FUNCTION int1_from_int2(int2) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_int2';
-
-CREATE FUNCTION int1_from_int4(int4) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_int4';
-
-CREATE FUNCTION int1_from_int8(int8) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_int8';
-
-CREATE FUNCTION int1_from_int16(int16) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_int16';
-
-CREATE FUNCTION int1_from_numeric(numeric) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_numeric';
-
-CREATE FUNCTION int1_from_float4(float4) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_float4';
-
-CREATE FUNCTION int1_from_float8(float8) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_float8';
-
-CREATE FUNCTION int1_from_json(json) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_json';
-
-CREATE FUNCTION int1_from_jsonb(jsonb) RETURNS int1
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int1_from_jsonb';
-
--- Type int2 block
-
--- Cast functions int2 block
-
-CREATE FUNCTION int2_from_uint1(uint1) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_uint1';
-
-CREATE FUNCTION int2_from_uint2(uint2) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_uint2';
-
-CREATE FUNCTION int2_from_uint4(uint4) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_uint4';
-
-CREATE FUNCTION int2_from_uint8(uint8) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_uint8';
-
-CREATE FUNCTION int2_from_uint16(uint16) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_uint16';
-
-CREATE FUNCTION int2_from_int1(int1) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_int1';
-
-CREATE FUNCTION int2_from_int16(int16) RETURNS int2
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int2_from_int16';
-
--- Type int4 block
-
--- Cast functions int4 block
-
-CREATE FUNCTION int4_from_uint1(uint1) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_uint1';
-
-CREATE FUNCTION int4_from_uint2(uint2) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_uint2';
-
-CREATE FUNCTION int4_from_uint4(uint4) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_uint4';
-
-CREATE FUNCTION int4_from_uint8(uint8) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_uint8';
-
-CREATE FUNCTION int4_from_uint16(uint16) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_uint16';
-
-CREATE FUNCTION int4_from_int1(int1) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_int1';
-
-CREATE FUNCTION int4_from_int16(int16) RETURNS int4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int4_from_int16';
-
--- Type int8 block
-
--- Cast functions int8 block
-
-CREATE FUNCTION int8_from_uint1(uint1) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_uint1';
-
-CREATE FUNCTION int8_from_uint2(uint2) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_uint2';
-
-CREATE FUNCTION int8_from_uint4(uint4) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_uint4';
-
-CREATE FUNCTION int8_from_uint8(uint8) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_uint8';
-
-CREATE FUNCTION int8_from_uint16(uint16) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_uint16';
-
-CREATE FUNCTION int8_from_int1(int1) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_int1';
-
-CREATE FUNCTION int8_from_int16(int16) RETURNS int8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int8_from_int16';
-
--- Type int16 block
-
--- Cast functions int16 block
-
-CREATE FUNCTION int16_from_uint1(uint1) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_uint1';
-
-CREATE FUNCTION int16_from_uint2(uint2) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_uint2';
-
-CREATE FUNCTION int16_from_uint4(uint4) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_uint4';
-
-CREATE FUNCTION int16_from_uint8(uint8) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_uint8';
-
-CREATE FUNCTION int16_from_uint16(uint16) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_uint16';
-
-CREATE FUNCTION int16_from_int1(int1) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_int1';
-
-CREATE FUNCTION int16_from_int2(int2) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_int2';
-
-CREATE FUNCTION int16_from_int4(int4) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_int4';
-
-CREATE FUNCTION int16_from_int8(int8) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_int8';
-
-CREATE FUNCTION int16_from_float4(float4) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_float4';
-
-CREATE FUNCTION int16_from_float8(float8) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_float8';
-
-CREATE FUNCTION int16_from_json(json) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_json';
-
-CREATE FUNCTION int16_from_jsonb(jsonb) RETURNS int16
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LANGUAGE C
-    AS '$libdir/uint128', 'int16_from_jsonb';
-
--- Type numeric block
-
--- Cast functions numeric block
-
-CREATE FUNCTION numeric_from_uint1(uint1) RETURNS numeric
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'numeric_from_uint1';
-
-CREATE FUNCTION numeric_from_uint2(uint2) RETURNS numeric
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'numeric_from_uint2';
-
-CREATE FUNCTION numeric_from_uint4(uint4) RETURNS numeric
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'numeric_from_uint4';
-
-CREATE FUNCTION numeric_from_int1(int1) RETURNS numeric
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'numeric_from_int1';
-
--- Type float4 block
-
--- Cast functions float4 block
-
-CREATE FUNCTION float4_from_uint1(uint1) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_uint1';
-
-CREATE FUNCTION float4_from_uint2(uint2) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_uint2';
-
-CREATE FUNCTION float4_from_uint4(uint4) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_uint4';
-
-CREATE FUNCTION float4_from_uint8(uint8) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_uint8';
-
-CREATE FUNCTION float4_from_uint16(uint16) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_uint16';
-
-CREATE FUNCTION float4_from_int1(int1) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_int1';
-
-CREATE FUNCTION float4_from_int16(int16) RETURNS float4
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float4_from_int16';
-
--- Type float8 block
-
--- Cast functions float8 block
-
-CREATE FUNCTION float8_from_uint1(uint1) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_uint1';
-
-CREATE FUNCTION float8_from_uint2(uint2) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_uint2';
-
-CREATE FUNCTION float8_from_uint4(uint4) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_uint4';
-
-CREATE FUNCTION float8_from_uint8(uint8) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_uint8';
-
-CREATE FUNCTION float8_from_uint16(uint16) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_uint16';
-
-CREATE FUNCTION float8_from_int1(int1) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_int1';
-
-CREATE FUNCTION float8_from_int16(int16) RETURNS float8
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'float8_from_int16';
-
--- Type json block
-
--- Cast functions json block
-
-CREATE FUNCTION json_from_uint1(uint1) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_uint1';
-
-CREATE FUNCTION json_from_uint2(uint2) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_uint2';
-
-CREATE FUNCTION json_from_uint4(uint4) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_uint4';
-
-CREATE FUNCTION json_from_uint8(uint8) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_uint8';
-
-CREATE FUNCTION json_from_uint16(uint16) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_uint16';
-
-CREATE FUNCTION json_from_int1(int1) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_int1';
-
-CREATE FUNCTION json_from_int16(int16) RETURNS json
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'json_from_int16';
-
--- Type jsonb block
-
--- Cast functions jsonb block
-
-CREATE FUNCTION jsonb_from_uint1(uint1) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_uint1';
-
-CREATE FUNCTION jsonb_from_uint2(uint2) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_uint2';
-
-CREATE FUNCTION jsonb_from_uint4(uint4) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_uint4';
-
-CREATE FUNCTION jsonb_from_uint8(uint8) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_uint8';
-
-CREATE FUNCTION jsonb_from_uint16(uint16) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_uint16';
-
-CREATE FUNCTION jsonb_from_int1(int1) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_int1';
-
-CREATE FUNCTION jsonb_from_int16(int16) RETURNS jsonb
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'jsonb_from_int16';
-
--- Type uuid block
-
--- Cast functions uuid block
-
-CREATE FUNCTION uuid_from_uint16(uint16) RETURNS uuid
-    IMMUTABLE
-    PARALLEL SAFE
-    STRICT
-    LEAKPROOF
-    LANGUAGE C
-    AS '$libdir/uint128', 'uuid_from_uint16';
 
 -- Casts uint1 block
 
@@ -1417,4 +1409,37 @@ CREATE CAST (int16 AS jsonb) WITH FUNCTION jsonb_from_int16(int16) AS IMPLICIT;
 -- Casts uuid block
 
 CREATE CAST (uint16 AS uuid) WITH FUNCTION uuid_from_uint16(uint16) AS IMPLICIT;
+
+-- Cleanup old cast functions
+
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT
+            p.oid,
+            p.castfunc,
+            p.castsource,
+            p.casttarget
+        FROM
+            pg_catalog.pg_extension AS e
+        JOIN pg_catalog.pg_depend AS d ON d.refobjid = e.oid
+        JOIN pg_catalog.pg_cast AS p ON p.oid = d.objid
+        JOIN pg_type AS t ON t.oid = p.casttarget AND t.typtype NOT IN ('r', 'm')
+        JOIN pg_type AS t2 ON t2.oid = p.castsource AND t2.typtype NOT IN ('r', 'm')
+        WHERE
+            d.deptype = 'e'
+            AND e.extname = 'uint128'
+        ORDER BY 3, 4
+    LOOP
+--         RAISE NOTICE 'Dropping cast (% -> %)', r.castsource::regtype, r.casttarget::regtype;
+--         EXECUTE format('DROP CAST (%s AS %s)', r.castsource::regtype, r.casttarget::regtype);
+
+        IF r.castfunc IS NOT NULL AND r.castfunc > 0 AND r.castfunc::regprocedure::text LIKE '%_to_%' THEN
+            RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
+            EXECUTE format('DROP FUNCTION %s', r.castfunc::regprocedure);
+        END IF;
+    END LOOP;
+END $$;
 

--- a/uint128--1.1.1--1.2.0.sql
+++ b/uint128--1.1.1--1.2.0.sql
@@ -1,0 +1,1420 @@
+-- Cleanup old casts 
+
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT
+            p.oid,
+            p.castfunc,
+            p.castsource,
+            p.casttarget
+        FROM
+            pg_catalog.pg_extension AS e
+        JOIN pg_catalog.pg_depend AS d ON d.refobjid = e.oid
+        JOIN pg_catalog.pg_cast AS p ON p.oid = d.objid
+        JOIN pg_type AS t ON t.oid = p.casttarget AND t.typtype NOT IN ('r', 'm')
+        JOIN pg_type AS t2 ON t2.oid = p.castsource AND t2.typtype NOT IN ('r', 'm')
+        WHERE
+            d.deptype = 'e'
+            AND e.extname = 'uint128'
+            AND (p.castsource, p.casttarget) NOT IN (
+                ('int16'::regtype, 'numeric'::regtype),
+                ('numeric'::regtype, 'int16'::regtype),
+                ('uint16'::regtype, 'numeric'::regtype),
+                ('numeric'::regtype, 'uint16'::regtype),
+                ('uint8'::regtype, 'numeric'::regtype),
+                ('numeric'::regtype, 'uint8'::regtype)
+            )
+        ORDER BY 3, 4
+    LOOP
+        RAISE NOTICE 'Dropping cast (% -> %)', r.castsource::regtype, r.casttarget::regtype;
+        EXECUTE format('DROP CAST (%I AS %I)', r.castsource::regtype, r.casttarget::regtype);
+
+        IF r.castfunc IS NOT NULL AND r.castfunc > 0 THEN
+            RAISE NOTICE 'Dropping cast func %', r.castfunc::regprocedure;
+            EXECUTE format('DROP FUNCTION %I', r.castfunc::regprocedure);
+        END IF;
+    END LOOP;
+END $$;
+
+-- Type uint1 block
+
+-- Cast functions uint1 block
+
+CREATE FUNCTION uint1_from_int1(int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int1';
+
+CREATE FUNCTION uint1_from_int2(int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int2';
+
+CREATE FUNCTION uint1_from_int4(int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int4';
+
+CREATE FUNCTION uint1_from_int8(int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int8';
+
+CREATE FUNCTION uint1_from_int16(int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int16';
+
+CREATE FUNCTION uint1_from_uint2(uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint2';
+
+CREATE FUNCTION uint1_from_uint4(uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint4';
+
+CREATE FUNCTION uint1_from_uint8(uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint8';
+
+CREATE FUNCTION uint1_from_uint16(uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint16';
+
+CREATE FUNCTION uint1_from_numeric(numeric) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_numeric';
+
+CREATE FUNCTION uint1_from_float4(float4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_float4';
+
+CREATE FUNCTION uint1_from_float8(float8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_float8';
+
+CREATE FUNCTION uint1_from_json(json) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_json';
+
+CREATE FUNCTION uint1_from_jsonb(jsonb) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_jsonb';
+
+-- Type uint2 block
+
+-- Cast functions uint2 block
+
+CREATE FUNCTION uint2_from_int1(int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int1';
+
+CREATE FUNCTION uint2_from_int2(int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int2';
+
+CREATE FUNCTION uint2_from_int4(int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int4';
+
+CREATE FUNCTION uint2_from_int8(int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int8';
+
+CREATE FUNCTION uint2_from_int16(int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int16';
+
+CREATE FUNCTION uint2_from_uint1(uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint1';
+
+CREATE FUNCTION uint2_from_uint4(uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint4';
+
+CREATE FUNCTION uint2_from_uint8(uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint8';
+
+CREATE FUNCTION uint2_from_uint16(uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint16';
+
+CREATE FUNCTION uint2_from_numeric(numeric) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_numeric';
+
+CREATE FUNCTION uint2_from_float4(float4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_float4';
+
+CREATE FUNCTION uint2_from_float8(float8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_float8';
+
+CREATE FUNCTION uint2_from_json(json) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_json';
+
+CREATE FUNCTION uint2_from_jsonb(jsonb) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_jsonb';
+
+-- Type uint4 block
+
+-- Cast functions uint4 block
+
+CREATE FUNCTION uint4_from_int1(int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int1';
+
+CREATE FUNCTION uint4_from_int2(int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int2';
+
+CREATE FUNCTION uint4_from_int4(int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int4';
+
+CREATE FUNCTION uint4_from_int8(int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int8';
+
+CREATE FUNCTION uint4_from_int16(int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int16';
+
+CREATE FUNCTION uint4_from_uint1(uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint1';
+
+CREATE FUNCTION uint4_from_uint2(uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint2';
+
+CREATE FUNCTION uint4_from_uint8(uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint8';
+
+CREATE FUNCTION uint4_from_uint16(uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint16';
+
+CREATE FUNCTION uint4_from_numeric(numeric) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_numeric';
+
+CREATE FUNCTION uint4_from_float4(float4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_float4';
+
+CREATE FUNCTION uint4_from_float8(float8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_float8';
+
+CREATE FUNCTION uint4_from_json(json) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_json';
+
+CREATE FUNCTION uint4_from_jsonb(jsonb) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_jsonb';
+
+-- Type uint8 block
+
+-- Cast functions uint8 block
+
+CREATE FUNCTION uint8_from_int1(int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int1';
+
+CREATE FUNCTION uint8_from_int2(int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int2';
+
+CREATE FUNCTION uint8_from_int4(int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int4';
+
+CREATE FUNCTION uint8_from_int8(int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int8';
+
+CREATE FUNCTION uint8_from_int16(int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int16';
+
+CREATE FUNCTION uint8_from_uint1(uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint1';
+
+CREATE FUNCTION uint8_from_uint2(uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint2';
+
+CREATE FUNCTION uint8_from_uint4(uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint4';
+
+CREATE FUNCTION uint8_from_uint16(uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint16';
+
+CREATE FUNCTION uint8_from_float4(float4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_float4';
+
+CREATE FUNCTION uint8_from_float8(float8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_float8';
+
+CREATE FUNCTION uint8_from_json(json) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_json';
+
+CREATE FUNCTION uint8_from_jsonb(jsonb) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_jsonb';
+
+-- Type uint16 block
+
+-- Cast functions uint16 block
+
+CREATE FUNCTION uint16_from_int1(int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int1';
+
+CREATE FUNCTION uint16_from_int2(int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int2';
+
+CREATE FUNCTION uint16_from_int4(int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int4';
+
+CREATE FUNCTION uint16_from_int8(int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int8';
+
+CREATE FUNCTION uint16_from_int16(int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int16';
+
+CREATE FUNCTION uint16_from_uint1(uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint1';
+
+CREATE FUNCTION uint16_from_uint2(uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint2';
+
+CREATE FUNCTION uint16_from_uint4(uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint4';
+
+CREATE FUNCTION uint16_from_uint8(uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint8';
+
+CREATE FUNCTION uint16_from_float4(float4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_float4';
+
+CREATE FUNCTION uint16_from_float8(float8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_float8';
+
+CREATE FUNCTION uint16_from_json(json) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_json';
+
+CREATE FUNCTION uint16_from_jsonb(jsonb) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_jsonb';
+
+CREATE FUNCTION uint16_from_uuid(uuid) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uuid';
+
+-- Type int1 block
+
+-- Cast functions int1 block
+
+CREATE FUNCTION int1_from_uint1(uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint1';
+
+CREATE FUNCTION int1_from_uint2(uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint2';
+
+CREATE FUNCTION int1_from_uint4(uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint4';
+
+CREATE FUNCTION int1_from_uint8(uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint8';
+
+CREATE FUNCTION int1_from_uint16(uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint16';
+
+CREATE FUNCTION int1_from_int2(int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int2';
+
+CREATE FUNCTION int1_from_int4(int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int4';
+
+CREATE FUNCTION int1_from_int8(int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int8';
+
+CREATE FUNCTION int1_from_int16(int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int16';
+
+CREATE FUNCTION int1_from_numeric(numeric) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_numeric';
+
+CREATE FUNCTION int1_from_float4(float4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_float4';
+
+CREATE FUNCTION int1_from_float8(float8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_float8';
+
+CREATE FUNCTION int1_from_json(json) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_json';
+
+CREATE FUNCTION int1_from_jsonb(jsonb) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_jsonb';
+
+-- Type int2 block
+
+-- Cast functions int2 block
+
+CREATE FUNCTION int2_from_uint1(uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint1';
+
+CREATE FUNCTION int2_from_uint2(uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint2';
+
+CREATE FUNCTION int2_from_uint4(uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint4';
+
+CREATE FUNCTION int2_from_uint8(uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint8';
+
+CREATE FUNCTION int2_from_uint16(uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint16';
+
+CREATE FUNCTION int2_from_int1(int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_int1';
+
+CREATE FUNCTION int2_from_int16(int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_int16';
+
+-- Type int4 block
+
+-- Cast functions int4 block
+
+CREATE FUNCTION int4_from_uint1(uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint1';
+
+CREATE FUNCTION int4_from_uint2(uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint2';
+
+CREATE FUNCTION int4_from_uint4(uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint4';
+
+CREATE FUNCTION int4_from_uint8(uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint8';
+
+CREATE FUNCTION int4_from_uint16(uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint16';
+
+CREATE FUNCTION int4_from_int1(int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_int1';
+
+CREATE FUNCTION int4_from_int16(int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_int16';
+
+-- Type int8 block
+
+-- Cast functions int8 block
+
+CREATE FUNCTION int8_from_uint1(uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint1';
+
+CREATE FUNCTION int8_from_uint2(uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint2';
+
+CREATE FUNCTION int8_from_uint4(uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint4';
+
+CREATE FUNCTION int8_from_uint8(uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint8';
+
+CREATE FUNCTION int8_from_uint16(uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint16';
+
+CREATE FUNCTION int8_from_int1(int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_int1';
+
+CREATE FUNCTION int8_from_int16(int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_int16';
+
+-- Type int16 block
+
+-- Cast functions int16 block
+
+CREATE FUNCTION int16_from_uint1(uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint1';
+
+CREATE FUNCTION int16_from_uint2(uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint2';
+
+CREATE FUNCTION int16_from_uint4(uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint4';
+
+CREATE FUNCTION int16_from_uint8(uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint8';
+
+CREATE FUNCTION int16_from_uint16(uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint16';
+
+CREATE FUNCTION int16_from_int1(int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int1';
+
+CREATE FUNCTION int16_from_int2(int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int2';
+
+CREATE FUNCTION int16_from_int4(int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int4';
+
+CREATE FUNCTION int16_from_int8(int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int8';
+
+CREATE FUNCTION int16_from_float4(float4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_float4';
+
+CREATE FUNCTION int16_from_float8(float8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_float8';
+
+CREATE FUNCTION int16_from_json(json) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_json';
+
+CREATE FUNCTION int16_from_jsonb(jsonb) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_jsonb';
+
+-- Type numeric block
+
+-- Cast functions numeric block
+
+CREATE FUNCTION numeric_from_uint1(uint1) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint1';
+
+CREATE FUNCTION numeric_from_uint2(uint2) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint2';
+
+CREATE FUNCTION numeric_from_uint4(uint4) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint4';
+
+CREATE FUNCTION numeric_from_int1(int1) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_int1';
+
+-- Type float4 block
+
+-- Cast functions float4 block
+
+CREATE FUNCTION float4_from_uint1(uint1) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint1';
+
+CREATE FUNCTION float4_from_uint2(uint2) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint2';
+
+CREATE FUNCTION float4_from_uint4(uint4) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint4';
+
+CREATE FUNCTION float4_from_uint8(uint8) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint8';
+
+CREATE FUNCTION float4_from_uint16(uint16) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint16';
+
+CREATE FUNCTION float4_from_int1(int1) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_int1';
+
+CREATE FUNCTION float4_from_int16(int16) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_int16';
+
+-- Type float8 block
+
+-- Cast functions float8 block
+
+CREATE FUNCTION float8_from_uint1(uint1) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint1';
+
+CREATE FUNCTION float8_from_uint2(uint2) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint2';
+
+CREATE FUNCTION float8_from_uint4(uint4) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint4';
+
+CREATE FUNCTION float8_from_uint8(uint8) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint8';
+
+CREATE FUNCTION float8_from_uint16(uint16) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint16';
+
+CREATE FUNCTION float8_from_int1(int1) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_int1';
+
+CREATE FUNCTION float8_from_int16(int16) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_int16';
+
+-- Type json block
+
+-- Cast functions json block
+
+CREATE FUNCTION json_from_uint1(uint1) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint1';
+
+CREATE FUNCTION json_from_uint2(uint2) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint2';
+
+CREATE FUNCTION json_from_uint4(uint4) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint4';
+
+CREATE FUNCTION json_from_uint8(uint8) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint8';
+
+CREATE FUNCTION json_from_uint16(uint16) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint16';
+
+CREATE FUNCTION json_from_int1(int1) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_int1';
+
+CREATE FUNCTION json_from_int16(int16) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_int16';
+
+-- Type jsonb block
+
+-- Cast functions jsonb block
+
+CREATE FUNCTION jsonb_from_uint1(uint1) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint1';
+
+CREATE FUNCTION jsonb_from_uint2(uint2) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint2';
+
+CREATE FUNCTION jsonb_from_uint4(uint4) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint4';
+
+CREATE FUNCTION jsonb_from_uint8(uint8) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint8';
+
+CREATE FUNCTION jsonb_from_uint16(uint16) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint16';
+
+CREATE FUNCTION jsonb_from_int1(int1) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_int1';
+
+CREATE FUNCTION jsonb_from_int16(int16) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_int16';
+
+-- Type uuid block
+
+-- Cast functions uuid block
+
+CREATE FUNCTION uuid_from_uint16(uint16) RETURNS uuid
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uuid_from_uint16';
+
+-- Casts uint1 block
+
+CREATE CAST (int1 AS uint1) WITH FUNCTION uint1_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint1) WITH FUNCTION uint1_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint1) WITH FUNCTION uint1_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint1) WITH FUNCTION uint1_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint1) WITH FUNCTION uint1_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint2 AS uint1) WITH FUNCTION uint1_from_uint2(uint2) AS ASSIGNMENT;
+CREATE CAST (uint4 AS uint1) WITH FUNCTION uint1_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS uint1) WITH FUNCTION uint1_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS uint1) WITH FUNCTION uint1_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint1) WITH FUNCTION uint1_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint1) WITH FUNCTION uint1_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint1) WITH FUNCTION uint1_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint1) WITH FUNCTION uint1_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint1) WITH FUNCTION uint1_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Casts uint2 block
+
+CREATE CAST (int1 AS uint2) WITH FUNCTION uint2_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint2) WITH FUNCTION uint2_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint2) WITH FUNCTION uint2_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint2) WITH FUNCTION uint2_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint2) WITH FUNCTION uint2_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint2) WITH FUNCTION uint2_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint4 AS uint2) WITH FUNCTION uint2_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS uint2) WITH FUNCTION uint2_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS uint2) WITH FUNCTION uint2_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint2) WITH FUNCTION uint2_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint2) WITH FUNCTION uint2_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint2) WITH FUNCTION uint2_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint2) WITH FUNCTION uint2_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint2) WITH FUNCTION uint2_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Casts uint4 block
+
+CREATE CAST (int1 AS uint4) WITH FUNCTION uint4_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint4) WITH FUNCTION uint4_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint4) WITH FUNCTION uint4_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint4) WITH FUNCTION uint4_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint4) WITH FUNCTION uint4_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint4) WITH FUNCTION uint4_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS uint4) WITH FUNCTION uint4_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint8 AS uint4) WITH FUNCTION uint4_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS uint4) WITH FUNCTION uint4_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint4) WITH FUNCTION uint4_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint4) WITH FUNCTION uint4_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint4) WITH FUNCTION uint4_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint4) WITH FUNCTION uint4_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint4) WITH FUNCTION uint4_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Casts uint8 block
+
+CREATE CAST (int1 AS uint8) WITH FUNCTION uint8_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint8) WITH FUNCTION uint8_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint8) WITH FUNCTION uint8_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint8) WITH FUNCTION uint8_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint8) WITH FUNCTION uint8_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint8) WITH FUNCTION uint8_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS uint8) WITH FUNCTION uint8_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS uint8) WITH FUNCTION uint8_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint16 AS uint8) WITH FUNCTION uint8_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint8) WITH FUNCTION uint8_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint8) WITH FUNCTION uint8_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint8) WITH FUNCTION uint8_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint8) WITH FUNCTION uint8_from_jsonb(jsonb) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint8) WITH INOUT AS ASSIGNMENT;
+
+-- Casts uint16 block
+
+CREATE CAST (int1 AS uint16) WITH FUNCTION uint16_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint16) WITH FUNCTION uint16_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint16) WITH FUNCTION uint16_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint16) WITH FUNCTION uint16_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint16) WITH FUNCTION uint16_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint16) WITH FUNCTION uint16_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS uint16) WITH FUNCTION uint16_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS uint16) WITH FUNCTION uint16_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS uint16) WITH FUNCTION uint16_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (float4 AS uint16) WITH FUNCTION uint16_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint16) WITH FUNCTION uint16_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint16) WITH FUNCTION uint16_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint16) WITH FUNCTION uint16_from_jsonb(jsonb) AS ASSIGNMENT;
+CREATE CAST (uuid AS uint16) WITH FUNCTION uint16_from_uuid(uuid) AS IMPLICIT;
+CREATE CAST (numeric AS uint16) WITH INOUT AS ASSIGNMENT;
+
+-- Casts int1 block
+
+CREATE CAST (uint1 AS int1) WITH FUNCTION int1_from_uint1(uint1) AS ASSIGNMENT;
+CREATE CAST (uint2 AS int1) WITH FUNCTION int1_from_uint2(uint2) AS ASSIGNMENT;
+CREATE CAST (uint4 AS int1) WITH FUNCTION int1_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS int1) WITH FUNCTION int1_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int1) WITH FUNCTION int1_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int2 AS int1) WITH FUNCTION int1_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS int1) WITH FUNCTION int1_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS int1) WITH FUNCTION int1_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS int1) WITH FUNCTION int1_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (numeric AS int1) WITH FUNCTION int1_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS int1) WITH FUNCTION int1_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS int1) WITH FUNCTION int1_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS int1) WITH FUNCTION int1_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS int1) WITH FUNCTION int1_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Casts int2 block
+
+CREATE CAST (uint1 AS int2) WITH FUNCTION int2_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int2) WITH FUNCTION int2_from_uint2(uint2) AS ASSIGNMENT;
+CREATE CAST (uint4 AS int2) WITH FUNCTION int2_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS int2) WITH FUNCTION int2_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int2) WITH FUNCTION int2_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int2) WITH FUNCTION int2_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS int2) WITH FUNCTION int2_from_int16(int16) AS ASSIGNMENT;
+
+-- Casts int4 block
+
+CREATE CAST (uint1 AS int4) WITH FUNCTION int4_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int4) WITH FUNCTION int4_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS int4) WITH FUNCTION int4_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS int4) WITH FUNCTION int4_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int4) WITH FUNCTION int4_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int4) WITH FUNCTION int4_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS int4) WITH FUNCTION int4_from_int16(int16) AS ASSIGNMENT;
+
+-- Casts int8 block
+
+CREATE CAST (uint1 AS int8) WITH FUNCTION int8_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int8) WITH FUNCTION int8_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS int8) WITH FUNCTION int8_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS int8) WITH FUNCTION int8_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int8) WITH FUNCTION int8_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int8) WITH FUNCTION int8_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS int8) WITH FUNCTION int8_from_int16(int16) AS ASSIGNMENT;
+
+-- Casts int16 block
+
+CREATE CAST (uint1 AS int16) WITH FUNCTION int16_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int16) WITH FUNCTION int16_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS int16) WITH FUNCTION int16_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS int16) WITH FUNCTION int16_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS int16) WITH FUNCTION int16_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int16) WITH FUNCTION int16_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int2 AS int16) WITH FUNCTION int16_from_int2(int2) AS IMPLICIT;
+CREATE CAST (int4 AS int16) WITH FUNCTION int16_from_int4(int4) AS IMPLICIT;
+CREATE CAST (int8 AS int16) WITH FUNCTION int16_from_int8(int8) AS IMPLICIT;
+CREATE CAST (float4 AS int16) WITH FUNCTION int16_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS int16) WITH FUNCTION int16_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS int16) WITH FUNCTION int16_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS int16) WITH FUNCTION int16_from_jsonb(jsonb) AS ASSIGNMENT;
+CREATE CAST (numeric AS int16) WITH INOUT AS ASSIGNMENT;
+
+-- Casts numeric block
+
+CREATE CAST (uint1 AS numeric) WITH FUNCTION numeric_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS numeric) WITH FUNCTION numeric_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS numeric) WITH FUNCTION numeric_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (int1 AS numeric) WITH FUNCTION numeric_from_int1(int1) AS IMPLICIT;
+CREATE CAST (uint8 AS numeric) WITH INOUT AS IMPLICIT;
+CREATE CAST (uint16 AS numeric) WITH INOUT AS IMPLICIT;
+CREATE CAST (int16 AS numeric) WITH INOUT AS IMPLICIT;
+
+-- Casts float4 block
+
+CREATE CAST (uint1 AS float4) WITH FUNCTION float4_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS float4) WITH FUNCTION float4_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS float4) WITH FUNCTION float4_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS float4) WITH FUNCTION float4_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS float4) WITH FUNCTION float4_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS float4) WITH FUNCTION float4_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS float4) WITH FUNCTION float4_from_int16(int16) AS IMPLICIT;
+
+-- Casts float8 block
+
+CREATE CAST (uint1 AS float8) WITH FUNCTION float8_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS float8) WITH FUNCTION float8_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS float8) WITH FUNCTION float8_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS float8) WITH FUNCTION float8_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS float8) WITH FUNCTION float8_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS float8) WITH FUNCTION float8_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS float8) WITH FUNCTION float8_from_int16(int16) AS IMPLICIT;
+
+-- Casts json block
+
+CREATE CAST (uint1 AS json) WITH FUNCTION json_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS json) WITH FUNCTION json_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS json) WITH FUNCTION json_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS json) WITH FUNCTION json_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS json) WITH FUNCTION json_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS json) WITH FUNCTION json_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS json) WITH FUNCTION json_from_int16(int16) AS IMPLICIT;
+
+-- Casts jsonb block
+
+CREATE CAST (uint1 AS jsonb) WITH FUNCTION jsonb_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS jsonb) WITH FUNCTION jsonb_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS jsonb) WITH FUNCTION jsonb_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS jsonb) WITH FUNCTION jsonb_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS jsonb) WITH FUNCTION jsonb_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS jsonb) WITH FUNCTION jsonb_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS jsonb) WITH FUNCTION jsonb_from_int16(int16) AS IMPLICIT;
+
+-- Casts uuid block
+
+CREATE CAST (uint16 AS uuid) WITH FUNCTION uuid_from_uint16(uint16) AS IMPLICIT;
+

--- a/uint128--1.1.1.sql
+++ b/uint128--1.1.1.sql
@@ -45,7 +45,7 @@ CREATE TYPE uint16 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint16) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint16 AS double precision) WITH INOUT AS IMPLICIT;
@@ -1809,7 +1809,7 @@ CREATE TYPE uint8 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint8) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint8 AS double precision) WITH INOUT AS IMPLICIT;
@@ -3557,7 +3557,7 @@ CREATE TYPE uint4 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint4) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint4 AS double precision) WITH INOUT AS IMPLICIT;
@@ -5305,7 +5305,7 @@ CREATE TYPE uint2 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint2) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint2 AS double precision) WITH INOUT AS IMPLICIT;
@@ -7053,7 +7053,7 @@ CREATE TYPE int16 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS int16) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (int16 AS double precision) WITH INOUT AS IMPLICIT;
@@ -8763,6 +8763,8 @@ CREATE TYPE int16range AS RANGE (
 
 
 -- Cross types ops
+-- Type uint16 block
+
 
 -- Casts block
 
@@ -9572,6 +9574,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint8 block
+
 
 -- Casts block
 
@@ -10365,6 +10369,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint4 block
+
 
 -- Casts block
 
@@ -11142,6 +11148,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint2 block
+
 
 -- Casts block
 
@@ -11902,6 +11910,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type int16 block
 
 
 -- Casts block
@@ -12695,7 +12705,7 @@ CREATE TYPE uint1 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS uint1) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (uint1 AS double precision) WITH INOUT AS IMPLICIT;
@@ -14443,7 +14453,7 @@ CREATE TYPE int1 (
 );
 
 
--- Inout casts block
+-- In-out casts block
 
 CREATE CAST (double precision AS int1) WITH INOUT AS ASSIGNMENT;
 CREATE CAST (int1 AS double precision) WITH INOUT AS IMPLICIT;
@@ -16153,6 +16163,8 @@ CREATE TYPE int1range AS RANGE (
 
 
 -- Cross types ops
+-- Type uint1 block
+
 
 -- Casts block
 
@@ -17352,6 +17364,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type int1 block
+
 
 -- Casts block
 
@@ -18535,6 +18549,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint16 block
+
 
 -- Casts block
 -- Ops block
@@ -18921,6 +18937,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type uint8 block
 
 
 -- Casts block
@@ -19309,6 +19327,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint4 block
+
 
 -- Casts block
 -- Ops block
@@ -19696,6 +19716,8 @@ CREATE OPERATOR % (
 
 
 
+-- Type uint2 block
+
 
 -- Casts block
 -- Ops block
@@ -20082,6 +20104,8 @@ CREATE OPERATOR % (
 
 
 
+
+-- Type int16 block
 
 
 -- Casts block
@@ -20474,6 +20498,8 @@ CREATE OPERATOR % (
 -- v1.1.1
 --
 
+-- Type uint1 block
+
 
 -- Casts block
 
@@ -20531,6 +20557,8 @@ CREATE CAST (numeric AS uint1) WITH FUNCTION uint1_from_numeric(numeric) AS ASSI
 
 DROP CAST (uint1 AS numeric);
 CREATE CAST (uint1 AS numeric) WITH FUNCTION uint1_to_numeric(uint1) AS IMPLICIT;
+-- Type uint2 block
+
 
 -- Casts block
 
@@ -20588,6 +20616,8 @@ CREATE CAST (numeric AS uint2) WITH FUNCTION uint2_from_numeric(numeric) AS ASSI
 
 DROP CAST (uint2 AS numeric);
 CREATE CAST (uint2 AS numeric) WITH FUNCTION uint2_to_numeric(uint2) AS IMPLICIT;
+-- Type uint4 block
+
 
 -- Casts block
 
@@ -20645,6 +20675,8 @@ CREATE CAST (numeric AS uint4) WITH FUNCTION uint4_from_numeric(numeric) AS ASSI
 
 DROP CAST (uint4 AS numeric);
 CREATE CAST (uint4 AS numeric) WITH FUNCTION uint4_to_numeric(uint4) AS IMPLICIT;
+-- Type uint8 block
+
 
 -- Casts block
 
@@ -20683,6 +20715,8 @@ CREATE CAST (uint8 AS jsonb) WITH FUNCTION uint8_to_jsonb(uint8) AS IMPLICIT;
 
 
 
+-- Type uint16 block
+
 
 -- Casts block
 
@@ -20720,6 +20754,8 @@ CREATE CAST (uint16 AS jsonb) WITH FUNCTION uint16_to_jsonb(uint16) AS IMPLICIT;
 -- Ops block
 
 
+
+-- Type int1 block
 
 
 -- Casts block
@@ -20778,6 +20814,8 @@ CREATE CAST (numeric AS int1) WITH FUNCTION int1_from_numeric(numeric) AS ASSIGN
 
 DROP CAST (int1 AS numeric);
 CREATE CAST (int1 AS numeric) WITH FUNCTION int1_to_numeric(int1) AS IMPLICIT;
+-- Type int16 block
+
 
 -- Casts block
 

--- a/uint128--1.2.0.sql
+++ b/uint128--1.2.0.sql
@@ -1,0 +1,20334 @@
+-- Type uint1 block
+
+CREATE FUNCTION uint1_in(cstring) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_in';
+
+CREATE FUNCTION uint1_out(uint1) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_out';
+
+CREATE FUNCTION uint1_recv(internal) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_recv';
+
+CREATE FUNCTION uint1_send(uint1) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_send';
+
+CREATE TYPE uint1 (
+    INPUT = uint1_in,
+    OUTPUT = uint1_out,
+    RECEIVE = uint1_recv,
+    SEND = uint1_send,
+    INTERNALLENGTH = 1,
+    PASSEDBYVALUE,
+    ALIGNMENT = char
+);
+
+
+CREATE FUNCTION uint1_eq_uint1(uint1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_uint1';
+CREATE FUNCTION uint1_ne_uint1(uint1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_uint1';
+CREATE FUNCTION uint1_gt_uint1(uint1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_uint1';
+CREATE FUNCTION uint1_lt_uint1(uint1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_uint1';
+CREATE FUNCTION uint1_ge_uint1(uint1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_uint1';
+CREATE FUNCTION uint1_le_uint1(uint1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_uint1';
+CREATE FUNCTION uint1_add_uint1(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_uint1';
+CREATE FUNCTION uint1_sub_uint1(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_uint1';
+CREATE FUNCTION uint1_mul_uint1(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_uint1';
+CREATE FUNCTION uint1_div_uint1(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_uint1';
+CREATE FUNCTION uint1_mod_uint1(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_uint1';
+CREATE FUNCTION uint1_xor(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_xor';
+CREATE FUNCTION uint1_and(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_and';
+CREATE FUNCTION uint1_or(uint1, uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_or';
+CREATE FUNCTION uint1_not(uint1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_not';
+CREATE FUNCTION uint1_shl(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_shl';
+CREATE FUNCTION uint1_shr(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_shr';
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_mul_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_div_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_mod_uint1
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=uint1,
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=uint1,
+    PROCEDURE=uint1_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION uint1_cmp(uint1, uint1) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_cmp';
+
+CREATE FUNCTION uint1_hash(uint1) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_hash';
+
+
+CREATE OPERATOR CLASS uint1_ops
+DEFAULT FOR TYPE uint1 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 uint1_cmp(uint1, uint1)
+;
+
+CREATE OPERATOR CLASS uint1_ops
+DEFAULT FOR TYPE uint1 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       uint1_hash(uint1);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint1'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint1_cmp(uint1, uint1)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint1'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint1_hash(uint1)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- Type uint2 block
+
+CREATE FUNCTION uint2_in(cstring) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_in';
+
+CREATE FUNCTION uint2_out(uint2) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_out';
+
+CREATE FUNCTION uint2_recv(internal) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_recv';
+
+CREATE FUNCTION uint2_send(uint2) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_send';
+
+CREATE TYPE uint2 (
+    INPUT = uint2_in,
+    OUTPUT = uint2_out,
+    RECEIVE = uint2_recv,
+    SEND = uint2_send,
+    INTERNALLENGTH = 2,
+    PASSEDBYVALUE,
+    ALIGNMENT = int2
+);
+
+
+CREATE FUNCTION uint2_eq_uint2(uint2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_uint2';
+CREATE FUNCTION uint2_ne_uint2(uint2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_uint2';
+CREATE FUNCTION uint2_gt_uint2(uint2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_uint2';
+CREATE FUNCTION uint2_lt_uint2(uint2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_uint2';
+CREATE FUNCTION uint2_ge_uint2(uint2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_uint2';
+CREATE FUNCTION uint2_le_uint2(uint2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_uint2';
+CREATE FUNCTION uint2_add_uint2(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_uint2';
+CREATE FUNCTION uint2_sub_uint2(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_uint2';
+CREATE FUNCTION uint2_mul_uint2(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_uint2';
+CREATE FUNCTION uint2_div_uint2(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_uint2';
+CREATE FUNCTION uint2_mod_uint2(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_uint2';
+CREATE FUNCTION uint2_xor(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_xor';
+CREATE FUNCTION uint2_and(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_and';
+CREATE FUNCTION uint2_or(uint2, uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_or';
+CREATE FUNCTION uint2_not(uint2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_not';
+CREATE FUNCTION uint2_shl(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_shl';
+CREATE FUNCTION uint2_shr(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_shr';
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_mul_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_div_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_mod_uint2
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=uint2,
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=uint2,
+    PROCEDURE=uint2_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION uint2_cmp(uint2, uint2) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_cmp';
+
+CREATE FUNCTION uint2_hash(uint2) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_hash';
+
+
+CREATE OPERATOR CLASS uint2_ops
+DEFAULT FOR TYPE uint2 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 uint2_cmp(uint2, uint2)
+;
+
+CREATE OPERATOR CLASS uint2_ops
+DEFAULT FOR TYPE uint2 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       uint2_hash(uint2);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint2'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint2_cmp(uint2, uint2)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint2'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint2_hash(uint2)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- Type uint4 block
+
+CREATE FUNCTION uint4_in(cstring) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_in';
+
+CREATE FUNCTION uint4_out(uint4) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_out';
+
+CREATE FUNCTION uint4_recv(internal) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_recv';
+
+CREATE FUNCTION uint4_send(uint4) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_send';
+
+CREATE TYPE uint4 (
+    INPUT = uint4_in,
+    OUTPUT = uint4_out,
+    RECEIVE = uint4_recv,
+    SEND = uint4_send,
+    INTERNALLENGTH = 4,
+    PASSEDBYVALUE,
+    ALIGNMENT = int4
+);
+
+
+CREATE FUNCTION uint4_eq_uint4(uint4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_uint4';
+CREATE FUNCTION uint4_ne_uint4(uint4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_uint4';
+CREATE FUNCTION uint4_gt_uint4(uint4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_uint4';
+CREATE FUNCTION uint4_lt_uint4(uint4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_uint4';
+CREATE FUNCTION uint4_ge_uint4(uint4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_uint4';
+CREATE FUNCTION uint4_le_uint4(uint4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_uint4';
+CREATE FUNCTION uint4_add_uint4(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_uint4';
+CREATE FUNCTION uint4_sub_uint4(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_uint4';
+CREATE FUNCTION uint4_mul_uint4(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_uint4';
+CREATE FUNCTION uint4_div_uint4(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_uint4';
+CREATE FUNCTION uint4_mod_uint4(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_uint4';
+CREATE FUNCTION uint4_xor(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_xor';
+CREATE FUNCTION uint4_and(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_and';
+CREATE FUNCTION uint4_or(uint4, uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_or';
+CREATE FUNCTION uint4_not(uint4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_not';
+CREATE FUNCTION uint4_shl(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_shl';
+CREATE FUNCTION uint4_shr(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_shr';
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_mul_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_div_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_mod_uint4
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=uint4,
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=uint4,
+    PROCEDURE=uint4_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION uint4_cmp(uint4, uint4) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_cmp';
+
+CREATE FUNCTION uint4_hash(uint4) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_hash';
+
+
+CREATE OPERATOR CLASS uint4_ops
+DEFAULT FOR TYPE uint4 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 uint4_cmp(uint4, uint4)
+;
+
+CREATE OPERATOR CLASS uint4_ops
+DEFAULT FOR TYPE uint4 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       uint4_hash(uint4);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint4'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint4_cmp(uint4, uint4)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint4'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint4_hash(uint4)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- Type uint8 block
+
+CREATE FUNCTION uint8_in(cstring) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_in';
+
+CREATE FUNCTION uint8_out(uint8) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_out';
+
+CREATE FUNCTION uint8_recv(internal) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_recv';
+
+CREATE FUNCTION uint8_send(uint8) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_send';
+
+CREATE TYPE uint8 (
+    INPUT = uint8_in,
+    OUTPUT = uint8_out,
+    RECEIVE = uint8_recv,
+    SEND = uint8_send,
+    INTERNALLENGTH = 8,
+    PASSEDBYVALUE,
+    ALIGNMENT = double
+);
+
+
+CREATE FUNCTION uint8_eq_uint8(uint8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_uint8';
+CREATE FUNCTION uint8_ne_uint8(uint8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_uint8';
+CREATE FUNCTION uint8_gt_uint8(uint8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_uint8';
+CREATE FUNCTION uint8_lt_uint8(uint8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_uint8';
+CREATE FUNCTION uint8_ge_uint8(uint8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_uint8';
+CREATE FUNCTION uint8_le_uint8(uint8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_uint8';
+CREATE FUNCTION uint8_add_uint8(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_uint8';
+CREATE FUNCTION uint8_sub_uint8(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_uint8';
+CREATE FUNCTION uint8_mul_uint8(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_uint8';
+CREATE FUNCTION uint8_div_uint8(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_uint8';
+CREATE FUNCTION uint8_mod_uint8(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_uint8';
+CREATE FUNCTION uint8_xor(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_xor';
+CREATE FUNCTION uint8_and(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_and';
+CREATE FUNCTION uint8_or(uint8, uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_or';
+CREATE FUNCTION uint8_not(uint8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_not';
+CREATE FUNCTION uint8_shl(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_shl';
+CREATE FUNCTION uint8_shr(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_shr';
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_mul_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_div_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_mod_uint8
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=uint8,
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=uint8,
+    PROCEDURE=uint8_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION uint8_cmp(uint8, uint8) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_cmp';
+
+CREATE FUNCTION uint8_hash(uint8) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_hash';
+
+
+CREATE OPERATOR CLASS uint8_ops
+DEFAULT FOR TYPE uint8 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 uint8_cmp(uint8, uint8)
+;
+
+CREATE OPERATOR CLASS uint8_ops
+DEFAULT FOR TYPE uint8 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       uint8_hash(uint8);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint8'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint8_cmp(uint8, uint8)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint8'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint8_hash(uint8)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- Type uint16 block
+
+CREATE FUNCTION uint16_in(cstring) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_in';
+
+CREATE FUNCTION uint16_out(uint16) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_out';
+
+CREATE FUNCTION uint16_recv(internal) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_recv';
+
+CREATE FUNCTION uint16_send(uint16) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_send';
+
+CREATE TYPE uint16 (
+    INPUT = uint16_in,
+    OUTPUT = uint16_out,
+    RECEIVE = uint16_recv,
+    SEND = uint16_send,
+    INTERNALLENGTH = 16,
+    --PASSEDBYVALUE,
+    ALIGNMENT = char
+);
+
+
+CREATE FUNCTION uint16_eq_uint16(uint16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_uint16';
+CREATE FUNCTION uint16_ne_uint16(uint16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_uint16';
+CREATE FUNCTION uint16_gt_uint16(uint16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_uint16';
+CREATE FUNCTION uint16_lt_uint16(uint16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_uint16';
+CREATE FUNCTION uint16_ge_uint16(uint16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_uint16';
+CREATE FUNCTION uint16_le_uint16(uint16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_uint16';
+CREATE FUNCTION uint16_add_uint16(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_uint16';
+CREATE FUNCTION uint16_sub_uint16(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_uint16';
+CREATE FUNCTION uint16_mul_uint16(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_uint16';
+CREATE FUNCTION uint16_div_uint16(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_uint16';
+CREATE FUNCTION uint16_mod_uint16(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_uint16';
+CREATE FUNCTION uint16_xor(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_xor';
+CREATE FUNCTION uint16_and(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_and';
+CREATE FUNCTION uint16_or(uint16, uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_or';
+CREATE FUNCTION uint16_not(uint16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_not';
+CREATE FUNCTION uint16_shl(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_shl';
+CREATE FUNCTION uint16_shr(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_shr';
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_mod_uint16
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=uint16,
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=uint16,
+    PROCEDURE=uint16_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION uint16_cmp(uint16, uint16) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_cmp';
+
+CREATE FUNCTION uint16_hash(uint16) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_hash';
+
+
+CREATE OPERATOR CLASS uint16_ops
+DEFAULT FOR TYPE uint16 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 uint16_cmp(uint16, uint16)
+;
+
+CREATE OPERATOR CLASS uint16_ops
+DEFAULT FOR TYPE uint16 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       uint16_hash(uint16);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint16'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint16_cmp(uint16, uint16)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'uint16'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'uint16_hash(uint16)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- Type int1 block
+
+CREATE FUNCTION int1_in(cstring) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_in';
+
+CREATE FUNCTION int1_out(int1) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_out';
+
+CREATE FUNCTION int1_recv(internal) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_recv';
+
+CREATE FUNCTION int1_send(int1) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_send';
+
+CREATE TYPE int1 (
+    INPUT = int1_in,
+    OUTPUT = int1_out,
+    RECEIVE = int1_recv,
+    SEND = int1_send,
+    INTERNALLENGTH = 1,
+    PASSEDBYVALUE,
+    ALIGNMENT = char
+);
+
+
+CREATE FUNCTION int1_eq_int1(int1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_int1';
+CREATE FUNCTION int1_ne_int1(int1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_int1';
+CREATE FUNCTION int1_gt_int1(int1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_int1';
+CREATE FUNCTION int1_lt_int1(int1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_int1';
+CREATE FUNCTION int1_ge_int1(int1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_int1';
+CREATE FUNCTION int1_le_int1(int1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_int1';
+CREATE FUNCTION int1_add_int1(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_int1';
+CREATE FUNCTION int1_sub_int1(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_int1';
+CREATE FUNCTION int1_mul_int1(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_int1';
+CREATE FUNCTION int1_div_int1(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_int1';
+CREATE FUNCTION int1_mod_int1(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_int1';
+CREATE FUNCTION int1_xor(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_xor';
+CREATE FUNCTION int1_and(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_and';
+CREATE FUNCTION int1_or(int1, int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_or';
+CREATE FUNCTION int1_not(int1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_not';
+CREATE FUNCTION int1_shl(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_shl';
+CREATE FUNCTION int1_shr(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_shr';
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_mul_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_div_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_mod_int1
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=int1,
+    RIGHTARG=int1,
+    PROCEDURE=int1_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=int1,
+    PROCEDURE=int1_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION int1_cmp(int1, int1) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_cmp';
+
+CREATE FUNCTION int1_hash(int1) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_hash';
+
+
+CREATE OPERATOR CLASS int1_ops
+DEFAULT FOR TYPE int1 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 int1_cmp(int1, int1)
+;
+
+CREATE OPERATOR CLASS int1_ops
+DEFAULT FOR TYPE int1 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       int1_hash(int1);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'int1'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'int1_cmp(int1, int1)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'int1'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'int1_hash(int1)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- Type int16 block
+
+CREATE FUNCTION int16_in(cstring) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_in';
+
+CREATE FUNCTION int16_out(int16) RETURNS cstring
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_out';
+
+CREATE FUNCTION int16_recv(internal) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_recv';
+
+CREATE FUNCTION int16_send(int16) RETURNS bytea
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_send';
+
+CREATE TYPE int16 (
+    INPUT = int16_in,
+    OUTPUT = int16_out,
+    RECEIVE = int16_recv,
+    SEND = int16_send,
+    INTERNALLENGTH = 16,
+    --PASSEDBYVALUE,
+    ALIGNMENT = char
+);
+
+
+CREATE FUNCTION int16_eq_int16(int16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_int16';
+CREATE FUNCTION int16_ne_int16(int16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_int16';
+CREATE FUNCTION int16_gt_int16(int16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_int16';
+CREATE FUNCTION int16_lt_int16(int16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_int16';
+CREATE FUNCTION int16_ge_int16(int16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_int16';
+CREATE FUNCTION int16_le_int16(int16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_int16';
+CREATE FUNCTION int16_add_int16(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_int16';
+CREATE FUNCTION int16_sub_int16(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_int16';
+CREATE FUNCTION int16_mul_int16(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_int16';
+CREATE FUNCTION int16_div_int16(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_int16';
+CREATE FUNCTION int16_mod_int16(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_int16';
+CREATE FUNCTION int16_xor(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_xor';
+CREATE FUNCTION int16_and(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_and';
+CREATE FUNCTION int16_or(int16, int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_or';
+CREATE FUNCTION int16_not(int16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_not';
+CREATE FUNCTION int16_shl(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_shl';
+CREATE FUNCTION int16_shr(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_shr';
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_mul_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_div_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_mod_int16
+);
+
+
+CREATE OPERATOR # (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_xor,
+    COMMUTATOR = #
+);
+
+
+CREATE OPERATOR & (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_and,
+    COMMUTATOR = &
+);
+
+
+CREATE OPERATOR | (
+    LEFTARG=int16,
+    RIGHTARG=int16,
+    PROCEDURE=int16_or,
+    COMMUTATOR = |
+);
+
+
+CREATE OPERATOR ~ (
+    RIGHTARG=int16,
+    PROCEDURE=int16_not
+);
+
+
+CREATE OPERATOR << (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_shl
+);
+
+
+CREATE OPERATOR >> (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_shr
+);
+
+
+
+-- Index ops block
+
+CREATE FUNCTION int16_cmp(int16, int16) RETURNS int
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_cmp';
+
+CREATE FUNCTION int16_hash(int16) RETURNS integer
+    IMMUTABLE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_hash';
+
+
+CREATE OPERATOR CLASS int16_ops
+DEFAULT FOR TYPE int16 USING btree FAMILY integer_ops AS
+    OPERATOR 1 <,
+    OPERATOR 2 <=,
+    OPERATOR 3 =,
+    OPERATOR 4 >=,
+    OPERATOR 5 >,
+    FUNCTION 1 int16_cmp(int16, int16)
+;
+
+CREATE OPERATOR CLASS int16_ops
+DEFAULT FOR TYPE int16 USING hash FAMILY integer_ops AS
+    OPERATOR        1       = ,
+    FUNCTION        1       int16_hash(int16);
+
+-- pg_depend records to prevent incorrect restoration order from binary dump
+
+-- BTREE OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'int16'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'btree'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON 
+        op.oprname IN ('<', '<=', '=', '>=', '>')
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'int16_cmp(int16, int16)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+-- HASH OPERATOR CLASS
+WITH typ AS (
+    SELECT 
+        typ.oid AS typ_oid,
+        pg_opclass.oid AS opc_oid
+        
+    FROM (SELECT 'int16'::regtype AS oid) typ
+
+    JOIN pg_opclass ON pg_opclass.opcintype = typ.oid
+    
+    -- Ensure BTREE operator family
+    JOIN pg_am ON pg_am.oid = pg_opclass.opcmethod AND pg_am.amname = 'hash'
+),
+operators AS (
+    SELECT op.oid, 'pg_operator'::regclass::oid AS refclassid
+    FROM typ
+    JOIN pg_operator op ON
+        op.oprname = '='
+        AND op.oprleft = typ.typ_oid
+        AND op.oprright = typ.typ_oid
+),
+fn AS (
+    SELECT
+        'int16_hash(int16)'::regprocedure::oid AS oid,
+        'pg_proc'::regclass::oid AS refclassid
+),
+deps AS (
+    SELECT * FROM operators
+    UNION ALL
+    SELECT * FROM fn
+)
+INSERT INTO pg_depend (classid, objid, objsubid, refclassid, refobjid, refobjsubid, deptype)
+SELECT DISTINCT ON (typ.opc_oid, deps.oid)
+    'pg_opclass'::regclass::oid AS classid,
+    typ.opc_oid AS objid,
+    0 AS objsubid,
+    deps.refclassid,
+    deps.oid AS refobjid,
+    0 AS refobjsubid,
+    'n' AS deptype
+
+FROM typ, deps
+
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM pg_depend
+	WHERE 
+		pg_depend.classid = 'pg_opclass'::regclass::oid 
+		AND pg_depend.objid = typ.opc_oid
+		AND pg_depend.refclassid = deps.refclassid
+		AND pg_depend.refobjid = deps.oid
+)
+
+ORDER BY typ.opc_oid, deps.oid;
+
+
+-- Cross-type operators for uint1
+
+CREATE FUNCTION uint1_eq_int1(uint1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_int1';
+CREATE FUNCTION uint1_eq_int2(uint1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_int2';
+CREATE FUNCTION uint1_eq_int4(uint1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_int4';
+CREATE FUNCTION uint1_eq_int8(uint1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_int8';
+CREATE FUNCTION uint1_eq_int16(uint1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_int16';
+CREATE FUNCTION uint1_eq_uint2(uint1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_uint2';
+CREATE FUNCTION uint1_eq_uint4(uint1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_uint4';
+CREATE FUNCTION uint1_eq_uint8(uint1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_uint8';
+CREATE FUNCTION uint1_eq_uint16(uint1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_eq_uint16';
+CREATE FUNCTION uint1_ne_int1(uint1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_int1';
+CREATE FUNCTION uint1_ne_int2(uint1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_int2';
+CREATE FUNCTION uint1_ne_int4(uint1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_int4';
+CREATE FUNCTION uint1_ne_int8(uint1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_int8';
+CREATE FUNCTION uint1_ne_int16(uint1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_int16';
+CREATE FUNCTION uint1_ne_uint2(uint1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_uint2';
+CREATE FUNCTION uint1_ne_uint4(uint1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_uint4';
+CREATE FUNCTION uint1_ne_uint8(uint1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_uint8';
+CREATE FUNCTION uint1_ne_uint16(uint1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ne_uint16';
+CREATE FUNCTION uint1_gt_int1(uint1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_int1';
+CREATE FUNCTION uint1_gt_int2(uint1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_int2';
+CREATE FUNCTION uint1_gt_int4(uint1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_int4';
+CREATE FUNCTION uint1_gt_int8(uint1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_int8';
+CREATE FUNCTION uint1_gt_int16(uint1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_int16';
+CREATE FUNCTION uint1_gt_uint2(uint1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_uint2';
+CREATE FUNCTION uint1_gt_uint4(uint1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_uint4';
+CREATE FUNCTION uint1_gt_uint8(uint1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_uint8';
+CREATE FUNCTION uint1_gt_uint16(uint1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_gt_uint16';
+CREATE FUNCTION uint1_lt_int1(uint1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_int1';
+CREATE FUNCTION uint1_lt_int2(uint1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_int2';
+CREATE FUNCTION uint1_lt_int4(uint1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_int4';
+CREATE FUNCTION uint1_lt_int8(uint1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_int8';
+CREATE FUNCTION uint1_lt_int16(uint1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_int16';
+CREATE FUNCTION uint1_lt_uint2(uint1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_uint2';
+CREATE FUNCTION uint1_lt_uint4(uint1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_uint4';
+CREATE FUNCTION uint1_lt_uint8(uint1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_uint8';
+CREATE FUNCTION uint1_lt_uint16(uint1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_lt_uint16';
+CREATE FUNCTION uint1_ge_int1(uint1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_int1';
+CREATE FUNCTION uint1_ge_int2(uint1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_int2';
+CREATE FUNCTION uint1_ge_int4(uint1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_int4';
+CREATE FUNCTION uint1_ge_int8(uint1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_int8';
+CREATE FUNCTION uint1_ge_int16(uint1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_int16';
+CREATE FUNCTION uint1_ge_uint2(uint1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_uint2';
+CREATE FUNCTION uint1_ge_uint4(uint1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_uint4';
+CREATE FUNCTION uint1_ge_uint8(uint1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_uint8';
+CREATE FUNCTION uint1_ge_uint16(uint1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_ge_uint16';
+CREATE FUNCTION uint1_le_int1(uint1, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_int1';
+CREATE FUNCTION uint1_le_int2(uint1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_int2';
+CREATE FUNCTION uint1_le_int4(uint1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_int4';
+CREATE FUNCTION uint1_le_int8(uint1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_int8';
+CREATE FUNCTION uint1_le_int16(uint1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_int16';
+CREATE FUNCTION uint1_le_uint2(uint1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_uint2';
+CREATE FUNCTION uint1_le_uint4(uint1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_uint4';
+CREATE FUNCTION uint1_le_uint8(uint1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_uint8';
+CREATE FUNCTION uint1_le_uint16(uint1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_le_uint16';
+CREATE FUNCTION uint1_add_int1(uint1, int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_int1';
+CREATE FUNCTION uint1_add_int2(uint1, int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_int2';
+CREATE FUNCTION uint1_add_int4(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_int4';
+CREATE FUNCTION uint1_add_int8(uint1, int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_int8';
+CREATE FUNCTION uint1_add_int16(uint1, int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_int16';
+CREATE FUNCTION uint1_add_uint2(uint1, uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_uint2';
+CREATE FUNCTION uint1_add_uint4(uint1, uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_uint4';
+CREATE FUNCTION uint1_add_uint8(uint1, uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_uint8';
+CREATE FUNCTION uint1_add_uint16(uint1, uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_add_uint16';
+CREATE FUNCTION uint1_sub_int1(uint1, int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_int1';
+CREATE FUNCTION uint1_sub_int2(uint1, int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_int2';
+CREATE FUNCTION uint1_sub_int4(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_int4';
+CREATE FUNCTION uint1_sub_int8(uint1, int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_int8';
+CREATE FUNCTION uint1_sub_int16(uint1, int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_int16';
+CREATE FUNCTION uint1_sub_uint2(uint1, uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_uint2';
+CREATE FUNCTION uint1_sub_uint4(uint1, uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_uint4';
+CREATE FUNCTION uint1_sub_uint8(uint1, uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_uint8';
+CREATE FUNCTION uint1_sub_uint16(uint1, uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_sub_uint16';
+CREATE FUNCTION uint1_mul_int1(uint1, int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_int1';
+CREATE FUNCTION uint1_mul_int2(uint1, int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_int2';
+CREATE FUNCTION uint1_mul_int4(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_int4';
+CREATE FUNCTION uint1_mul_int8(uint1, int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_int8';
+CREATE FUNCTION uint1_mul_int16(uint1, int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_int16';
+CREATE FUNCTION uint1_mul_uint2(uint1, uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_uint2';
+CREATE FUNCTION uint1_mul_uint4(uint1, uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_uint4';
+CREATE FUNCTION uint1_mul_uint8(uint1, uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_uint8';
+CREATE FUNCTION uint1_mul_uint16(uint1, uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mul_uint16';
+CREATE FUNCTION uint1_div_int1(uint1, int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_int1';
+CREATE FUNCTION uint1_div_int2(uint1, int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_int2';
+CREATE FUNCTION uint1_div_int4(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_int4';
+CREATE FUNCTION uint1_div_int8(uint1, int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_int8';
+CREATE FUNCTION uint1_div_int16(uint1, int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_int16';
+CREATE FUNCTION uint1_div_uint2(uint1, uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_uint2';
+CREATE FUNCTION uint1_div_uint4(uint1, uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_uint4';
+CREATE FUNCTION uint1_div_uint8(uint1, uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_uint8';
+CREATE FUNCTION uint1_div_uint16(uint1, uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_div_uint16';
+CREATE FUNCTION uint1_mod_int1(uint1, int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_int1';
+CREATE FUNCTION uint1_mod_int2(uint1, int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_int2';
+CREATE FUNCTION uint1_mod_int4(uint1, int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_int4';
+CREATE FUNCTION uint1_mod_int8(uint1, int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_int8';
+CREATE FUNCTION uint1_mod_int16(uint1, int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_int16';
+CREATE FUNCTION uint1_mod_uint2(uint1, uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_uint2';
+CREATE FUNCTION uint1_mod_uint4(uint1, uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_uint4';
+CREATE FUNCTION uint1_mod_uint8(uint1, uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_uint8';
+CREATE FUNCTION uint1_mod_uint16(uint1, uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=int1,
+    PROCEDURE=uint1_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=int2,
+    PROCEDURE=uint1_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=int4,
+    PROCEDURE=uint1_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=int8,
+    PROCEDURE=uint1_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=int16,
+    PROCEDURE=uint1_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=uint2,
+    PROCEDURE=uint1_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=uint4,
+    PROCEDURE=uint1_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=uint8,
+    PROCEDURE=uint1_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint1,
+    RIGHTARG=uint16,
+    PROCEDURE=uint1_mod_uint16
+);
+
+
+
+-- Cross-type operators for uint2
+
+CREATE FUNCTION uint2_eq_int1(uint2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_int1';
+CREATE FUNCTION uint2_eq_int2(uint2, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_int2';
+CREATE FUNCTION uint2_eq_int4(uint2, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_int4';
+CREATE FUNCTION uint2_eq_int8(uint2, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_int8';
+CREATE FUNCTION uint2_eq_int16(uint2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_int16';
+CREATE FUNCTION uint2_eq_uint1(uint2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_uint1';
+CREATE FUNCTION uint2_eq_uint4(uint2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_uint4';
+CREATE FUNCTION uint2_eq_uint8(uint2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_uint8';
+CREATE FUNCTION uint2_eq_uint16(uint2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_eq_uint16';
+CREATE FUNCTION uint2_ne_int1(uint2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_int1';
+CREATE FUNCTION uint2_ne_int2(uint2, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_int2';
+CREATE FUNCTION uint2_ne_int4(uint2, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_int4';
+CREATE FUNCTION uint2_ne_int8(uint2, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_int8';
+CREATE FUNCTION uint2_ne_int16(uint2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_int16';
+CREATE FUNCTION uint2_ne_uint1(uint2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_uint1';
+CREATE FUNCTION uint2_ne_uint4(uint2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_uint4';
+CREATE FUNCTION uint2_ne_uint8(uint2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_uint8';
+CREATE FUNCTION uint2_ne_uint16(uint2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ne_uint16';
+CREATE FUNCTION uint2_gt_int1(uint2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_int1';
+CREATE FUNCTION uint2_gt_int2(uint2, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_int2';
+CREATE FUNCTION uint2_gt_int4(uint2, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_int4';
+CREATE FUNCTION uint2_gt_int8(uint2, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_int8';
+CREATE FUNCTION uint2_gt_int16(uint2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_int16';
+CREATE FUNCTION uint2_gt_uint1(uint2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_uint1';
+CREATE FUNCTION uint2_gt_uint4(uint2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_uint4';
+CREATE FUNCTION uint2_gt_uint8(uint2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_uint8';
+CREATE FUNCTION uint2_gt_uint16(uint2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_gt_uint16';
+CREATE FUNCTION uint2_lt_int1(uint2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_int1';
+CREATE FUNCTION uint2_lt_int2(uint2, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_int2';
+CREATE FUNCTION uint2_lt_int4(uint2, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_int4';
+CREATE FUNCTION uint2_lt_int8(uint2, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_int8';
+CREATE FUNCTION uint2_lt_int16(uint2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_int16';
+CREATE FUNCTION uint2_lt_uint1(uint2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_uint1';
+CREATE FUNCTION uint2_lt_uint4(uint2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_uint4';
+CREATE FUNCTION uint2_lt_uint8(uint2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_uint8';
+CREATE FUNCTION uint2_lt_uint16(uint2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_lt_uint16';
+CREATE FUNCTION uint2_ge_int1(uint2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_int1';
+CREATE FUNCTION uint2_ge_int2(uint2, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_int2';
+CREATE FUNCTION uint2_ge_int4(uint2, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_int4';
+CREATE FUNCTION uint2_ge_int8(uint2, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_int8';
+CREATE FUNCTION uint2_ge_int16(uint2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_int16';
+CREATE FUNCTION uint2_ge_uint1(uint2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_uint1';
+CREATE FUNCTION uint2_ge_uint4(uint2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_uint4';
+CREATE FUNCTION uint2_ge_uint8(uint2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_uint8';
+CREATE FUNCTION uint2_ge_uint16(uint2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_ge_uint16';
+CREATE FUNCTION uint2_le_int1(uint2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_int1';
+CREATE FUNCTION uint2_le_int2(uint2, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_int2';
+CREATE FUNCTION uint2_le_int4(uint2, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_int4';
+CREATE FUNCTION uint2_le_int8(uint2, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_int8';
+CREATE FUNCTION uint2_le_int16(uint2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_int16';
+CREATE FUNCTION uint2_le_uint1(uint2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_uint1';
+CREATE FUNCTION uint2_le_uint4(uint2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_uint4';
+CREATE FUNCTION uint2_le_uint8(uint2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_uint8';
+CREATE FUNCTION uint2_le_uint16(uint2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_le_uint16';
+CREATE FUNCTION uint2_add_int1(uint2, int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_int1';
+CREATE FUNCTION uint2_add_int2(uint2, int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_int2';
+CREATE FUNCTION uint2_add_int4(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_int4';
+CREATE FUNCTION uint2_add_int8(uint2, int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_int8';
+CREATE FUNCTION uint2_add_int16(uint2, int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_int16';
+CREATE FUNCTION uint2_add_uint1(uint2, uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_uint1';
+CREATE FUNCTION uint2_add_uint4(uint2, uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_uint4';
+CREATE FUNCTION uint2_add_uint8(uint2, uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_uint8';
+CREATE FUNCTION uint2_add_uint16(uint2, uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_add_uint16';
+CREATE FUNCTION uint2_sub_int1(uint2, int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_int1';
+CREATE FUNCTION uint2_sub_int2(uint2, int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_int2';
+CREATE FUNCTION uint2_sub_int4(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_int4';
+CREATE FUNCTION uint2_sub_int8(uint2, int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_int8';
+CREATE FUNCTION uint2_sub_int16(uint2, int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_int16';
+CREATE FUNCTION uint2_sub_uint1(uint2, uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_uint1';
+CREATE FUNCTION uint2_sub_uint4(uint2, uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_uint4';
+CREATE FUNCTION uint2_sub_uint8(uint2, uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_uint8';
+CREATE FUNCTION uint2_sub_uint16(uint2, uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_sub_uint16';
+CREATE FUNCTION uint2_mul_int1(uint2, int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_int1';
+CREATE FUNCTION uint2_mul_int2(uint2, int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_int2';
+CREATE FUNCTION uint2_mul_int4(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_int4';
+CREATE FUNCTION uint2_mul_int8(uint2, int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_int8';
+CREATE FUNCTION uint2_mul_int16(uint2, int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_int16';
+CREATE FUNCTION uint2_mul_uint1(uint2, uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_uint1';
+CREATE FUNCTION uint2_mul_uint4(uint2, uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_uint4';
+CREATE FUNCTION uint2_mul_uint8(uint2, uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_uint8';
+CREATE FUNCTION uint2_mul_uint16(uint2, uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mul_uint16';
+CREATE FUNCTION uint2_div_int1(uint2, int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_int1';
+CREATE FUNCTION uint2_div_int2(uint2, int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_int2';
+CREATE FUNCTION uint2_div_int4(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_int4';
+CREATE FUNCTION uint2_div_int8(uint2, int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_int8';
+CREATE FUNCTION uint2_div_int16(uint2, int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_int16';
+CREATE FUNCTION uint2_div_uint1(uint2, uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_uint1';
+CREATE FUNCTION uint2_div_uint4(uint2, uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_uint4';
+CREATE FUNCTION uint2_div_uint8(uint2, uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_uint8';
+CREATE FUNCTION uint2_div_uint16(uint2, uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_div_uint16';
+CREATE FUNCTION uint2_mod_int1(uint2, int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_int1';
+CREATE FUNCTION uint2_mod_int2(uint2, int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_int2';
+CREATE FUNCTION uint2_mod_int4(uint2, int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_int4';
+CREATE FUNCTION uint2_mod_int8(uint2, int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_int8';
+CREATE FUNCTION uint2_mod_int16(uint2, int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_int16';
+CREATE FUNCTION uint2_mod_uint1(uint2, uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_uint1';
+CREATE FUNCTION uint2_mod_uint4(uint2, uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_uint4';
+CREATE FUNCTION uint2_mod_uint8(uint2, uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_uint8';
+CREATE FUNCTION uint2_mod_uint16(uint2, uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=int1,
+    PROCEDURE=uint2_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=int2,
+    PROCEDURE=uint2_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=int4,
+    PROCEDURE=uint2_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=int8,
+    PROCEDURE=uint2_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=int16,
+    PROCEDURE=uint2_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=uint1,
+    PROCEDURE=uint2_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=uint4,
+    PROCEDURE=uint2_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=uint8,
+    PROCEDURE=uint2_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint2,
+    RIGHTARG=uint16,
+    PROCEDURE=uint2_mod_uint16
+);
+
+
+
+-- Cross-type operators for uint4
+
+CREATE FUNCTION uint4_eq_int1(uint4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_int1';
+CREATE FUNCTION uint4_eq_int2(uint4, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_int2';
+CREATE FUNCTION uint4_eq_int4(uint4, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_int4';
+CREATE FUNCTION uint4_eq_int8(uint4, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_int8';
+CREATE FUNCTION uint4_eq_int16(uint4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_int16';
+CREATE FUNCTION uint4_eq_uint1(uint4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_uint1';
+CREATE FUNCTION uint4_eq_uint2(uint4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_uint2';
+CREATE FUNCTION uint4_eq_uint8(uint4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_uint8';
+CREATE FUNCTION uint4_eq_uint16(uint4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_eq_uint16';
+CREATE FUNCTION uint4_ne_int1(uint4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_int1';
+CREATE FUNCTION uint4_ne_int2(uint4, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_int2';
+CREATE FUNCTION uint4_ne_int4(uint4, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_int4';
+CREATE FUNCTION uint4_ne_int8(uint4, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_int8';
+CREATE FUNCTION uint4_ne_int16(uint4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_int16';
+CREATE FUNCTION uint4_ne_uint1(uint4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_uint1';
+CREATE FUNCTION uint4_ne_uint2(uint4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_uint2';
+CREATE FUNCTION uint4_ne_uint8(uint4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_uint8';
+CREATE FUNCTION uint4_ne_uint16(uint4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ne_uint16';
+CREATE FUNCTION uint4_gt_int1(uint4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_int1';
+CREATE FUNCTION uint4_gt_int2(uint4, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_int2';
+CREATE FUNCTION uint4_gt_int4(uint4, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_int4';
+CREATE FUNCTION uint4_gt_int8(uint4, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_int8';
+CREATE FUNCTION uint4_gt_int16(uint4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_int16';
+CREATE FUNCTION uint4_gt_uint1(uint4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_uint1';
+CREATE FUNCTION uint4_gt_uint2(uint4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_uint2';
+CREATE FUNCTION uint4_gt_uint8(uint4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_uint8';
+CREATE FUNCTION uint4_gt_uint16(uint4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_gt_uint16';
+CREATE FUNCTION uint4_lt_int1(uint4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_int1';
+CREATE FUNCTION uint4_lt_int2(uint4, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_int2';
+CREATE FUNCTION uint4_lt_int4(uint4, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_int4';
+CREATE FUNCTION uint4_lt_int8(uint4, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_int8';
+CREATE FUNCTION uint4_lt_int16(uint4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_int16';
+CREATE FUNCTION uint4_lt_uint1(uint4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_uint1';
+CREATE FUNCTION uint4_lt_uint2(uint4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_uint2';
+CREATE FUNCTION uint4_lt_uint8(uint4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_uint8';
+CREATE FUNCTION uint4_lt_uint16(uint4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_lt_uint16';
+CREATE FUNCTION uint4_ge_int1(uint4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_int1';
+CREATE FUNCTION uint4_ge_int2(uint4, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_int2';
+CREATE FUNCTION uint4_ge_int4(uint4, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_int4';
+CREATE FUNCTION uint4_ge_int8(uint4, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_int8';
+CREATE FUNCTION uint4_ge_int16(uint4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_int16';
+CREATE FUNCTION uint4_ge_uint1(uint4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_uint1';
+CREATE FUNCTION uint4_ge_uint2(uint4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_uint2';
+CREATE FUNCTION uint4_ge_uint8(uint4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_uint8';
+CREATE FUNCTION uint4_ge_uint16(uint4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_ge_uint16';
+CREATE FUNCTION uint4_le_int1(uint4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_int1';
+CREATE FUNCTION uint4_le_int2(uint4, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_int2';
+CREATE FUNCTION uint4_le_int4(uint4, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_int4';
+CREATE FUNCTION uint4_le_int8(uint4, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_int8';
+CREATE FUNCTION uint4_le_int16(uint4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_int16';
+CREATE FUNCTION uint4_le_uint1(uint4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_uint1';
+CREATE FUNCTION uint4_le_uint2(uint4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_uint2';
+CREATE FUNCTION uint4_le_uint8(uint4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_uint8';
+CREATE FUNCTION uint4_le_uint16(uint4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_le_uint16';
+CREATE FUNCTION uint4_add_int1(uint4, int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_int1';
+CREATE FUNCTION uint4_add_int2(uint4, int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_int2';
+CREATE FUNCTION uint4_add_int4(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_int4';
+CREATE FUNCTION uint4_add_int8(uint4, int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_int8';
+CREATE FUNCTION uint4_add_int16(uint4, int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_int16';
+CREATE FUNCTION uint4_add_uint1(uint4, uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_uint1';
+CREATE FUNCTION uint4_add_uint2(uint4, uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_uint2';
+CREATE FUNCTION uint4_add_uint8(uint4, uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_uint8';
+CREATE FUNCTION uint4_add_uint16(uint4, uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_add_uint16';
+CREATE FUNCTION uint4_sub_int1(uint4, int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_int1';
+CREATE FUNCTION uint4_sub_int2(uint4, int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_int2';
+CREATE FUNCTION uint4_sub_int4(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_int4';
+CREATE FUNCTION uint4_sub_int8(uint4, int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_int8';
+CREATE FUNCTION uint4_sub_int16(uint4, int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_int16';
+CREATE FUNCTION uint4_sub_uint1(uint4, uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_uint1';
+CREATE FUNCTION uint4_sub_uint2(uint4, uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_uint2';
+CREATE FUNCTION uint4_sub_uint8(uint4, uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_uint8';
+CREATE FUNCTION uint4_sub_uint16(uint4, uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_sub_uint16';
+CREATE FUNCTION uint4_mul_int1(uint4, int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_int1';
+CREATE FUNCTION uint4_mul_int2(uint4, int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_int2';
+CREATE FUNCTION uint4_mul_int4(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_int4';
+CREATE FUNCTION uint4_mul_int8(uint4, int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_int8';
+CREATE FUNCTION uint4_mul_int16(uint4, int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_int16';
+CREATE FUNCTION uint4_mul_uint1(uint4, uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_uint1';
+CREATE FUNCTION uint4_mul_uint2(uint4, uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_uint2';
+CREATE FUNCTION uint4_mul_uint8(uint4, uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_uint8';
+CREATE FUNCTION uint4_mul_uint16(uint4, uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mul_uint16';
+CREATE FUNCTION uint4_div_int1(uint4, int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_int1';
+CREATE FUNCTION uint4_div_int2(uint4, int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_int2';
+CREATE FUNCTION uint4_div_int4(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_int4';
+CREATE FUNCTION uint4_div_int8(uint4, int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_int8';
+CREATE FUNCTION uint4_div_int16(uint4, int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_int16';
+CREATE FUNCTION uint4_div_uint1(uint4, uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_uint1';
+CREATE FUNCTION uint4_div_uint2(uint4, uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_uint2';
+CREATE FUNCTION uint4_div_uint8(uint4, uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_uint8';
+CREATE FUNCTION uint4_div_uint16(uint4, uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_div_uint16';
+CREATE FUNCTION uint4_mod_int1(uint4, int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_int1';
+CREATE FUNCTION uint4_mod_int2(uint4, int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_int2';
+CREATE FUNCTION uint4_mod_int4(uint4, int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_int4';
+CREATE FUNCTION uint4_mod_int8(uint4, int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_int8';
+CREATE FUNCTION uint4_mod_int16(uint4, int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_int16';
+CREATE FUNCTION uint4_mod_uint1(uint4, uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_uint1';
+CREATE FUNCTION uint4_mod_uint2(uint4, uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_uint2';
+CREATE FUNCTION uint4_mod_uint8(uint4, uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_uint8';
+CREATE FUNCTION uint4_mod_uint16(uint4, uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=int1,
+    PROCEDURE=uint4_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=int2,
+    PROCEDURE=uint4_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=int4,
+    PROCEDURE=uint4_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=int8,
+    PROCEDURE=uint4_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=int16,
+    PROCEDURE=uint4_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=uint1,
+    PROCEDURE=uint4_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=uint2,
+    PROCEDURE=uint4_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=uint8,
+    PROCEDURE=uint4_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint4,
+    RIGHTARG=uint16,
+    PROCEDURE=uint4_mod_uint16
+);
+
+
+
+-- Cross-type operators for uint8
+
+CREATE FUNCTION uint8_eq_int1(uint8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_int1';
+CREATE FUNCTION uint8_eq_int2(uint8, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_int2';
+CREATE FUNCTION uint8_eq_int4(uint8, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_int4';
+CREATE FUNCTION uint8_eq_int8(uint8, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_int8';
+CREATE FUNCTION uint8_eq_int16(uint8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_int16';
+CREATE FUNCTION uint8_eq_uint1(uint8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_uint1';
+CREATE FUNCTION uint8_eq_uint2(uint8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_uint2';
+CREATE FUNCTION uint8_eq_uint4(uint8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_uint4';
+CREATE FUNCTION uint8_eq_uint16(uint8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_eq_uint16';
+CREATE FUNCTION uint8_ne_int1(uint8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_int1';
+CREATE FUNCTION uint8_ne_int2(uint8, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_int2';
+CREATE FUNCTION uint8_ne_int4(uint8, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_int4';
+CREATE FUNCTION uint8_ne_int8(uint8, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_int8';
+CREATE FUNCTION uint8_ne_int16(uint8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_int16';
+CREATE FUNCTION uint8_ne_uint1(uint8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_uint1';
+CREATE FUNCTION uint8_ne_uint2(uint8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_uint2';
+CREATE FUNCTION uint8_ne_uint4(uint8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_uint4';
+CREATE FUNCTION uint8_ne_uint16(uint8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ne_uint16';
+CREATE FUNCTION uint8_gt_int1(uint8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_int1';
+CREATE FUNCTION uint8_gt_int2(uint8, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_int2';
+CREATE FUNCTION uint8_gt_int4(uint8, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_int4';
+CREATE FUNCTION uint8_gt_int8(uint8, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_int8';
+CREATE FUNCTION uint8_gt_int16(uint8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_int16';
+CREATE FUNCTION uint8_gt_uint1(uint8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_uint1';
+CREATE FUNCTION uint8_gt_uint2(uint8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_uint2';
+CREATE FUNCTION uint8_gt_uint4(uint8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_uint4';
+CREATE FUNCTION uint8_gt_uint16(uint8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_gt_uint16';
+CREATE FUNCTION uint8_lt_int1(uint8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_int1';
+CREATE FUNCTION uint8_lt_int2(uint8, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_int2';
+CREATE FUNCTION uint8_lt_int4(uint8, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_int4';
+CREATE FUNCTION uint8_lt_int8(uint8, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_int8';
+CREATE FUNCTION uint8_lt_int16(uint8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_int16';
+CREATE FUNCTION uint8_lt_uint1(uint8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_uint1';
+CREATE FUNCTION uint8_lt_uint2(uint8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_uint2';
+CREATE FUNCTION uint8_lt_uint4(uint8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_uint4';
+CREATE FUNCTION uint8_lt_uint16(uint8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_lt_uint16';
+CREATE FUNCTION uint8_ge_int1(uint8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_int1';
+CREATE FUNCTION uint8_ge_int2(uint8, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_int2';
+CREATE FUNCTION uint8_ge_int4(uint8, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_int4';
+CREATE FUNCTION uint8_ge_int8(uint8, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_int8';
+CREATE FUNCTION uint8_ge_int16(uint8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_int16';
+CREATE FUNCTION uint8_ge_uint1(uint8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_uint1';
+CREATE FUNCTION uint8_ge_uint2(uint8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_uint2';
+CREATE FUNCTION uint8_ge_uint4(uint8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_uint4';
+CREATE FUNCTION uint8_ge_uint16(uint8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_ge_uint16';
+CREATE FUNCTION uint8_le_int1(uint8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_int1';
+CREATE FUNCTION uint8_le_int2(uint8, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_int2';
+CREATE FUNCTION uint8_le_int4(uint8, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_int4';
+CREATE FUNCTION uint8_le_int8(uint8, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_int8';
+CREATE FUNCTION uint8_le_int16(uint8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_int16';
+CREATE FUNCTION uint8_le_uint1(uint8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_uint1';
+CREATE FUNCTION uint8_le_uint2(uint8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_uint2';
+CREATE FUNCTION uint8_le_uint4(uint8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_uint4';
+CREATE FUNCTION uint8_le_uint16(uint8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_le_uint16';
+CREATE FUNCTION uint8_add_int1(uint8, int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_int1';
+CREATE FUNCTION uint8_add_int2(uint8, int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_int2';
+CREATE FUNCTION uint8_add_int4(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_int4';
+CREATE FUNCTION uint8_add_int8(uint8, int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_int8';
+CREATE FUNCTION uint8_add_int16(uint8, int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_int16';
+CREATE FUNCTION uint8_add_uint1(uint8, uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_uint1';
+CREATE FUNCTION uint8_add_uint2(uint8, uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_uint2';
+CREATE FUNCTION uint8_add_uint4(uint8, uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_uint4';
+CREATE FUNCTION uint8_add_uint16(uint8, uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_add_uint16';
+CREATE FUNCTION uint8_sub_int1(uint8, int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_int1';
+CREATE FUNCTION uint8_sub_int2(uint8, int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_int2';
+CREATE FUNCTION uint8_sub_int4(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_int4';
+CREATE FUNCTION uint8_sub_int8(uint8, int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_int8';
+CREATE FUNCTION uint8_sub_int16(uint8, int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_int16';
+CREATE FUNCTION uint8_sub_uint1(uint8, uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_uint1';
+CREATE FUNCTION uint8_sub_uint2(uint8, uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_uint2';
+CREATE FUNCTION uint8_sub_uint4(uint8, uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_uint4';
+CREATE FUNCTION uint8_sub_uint16(uint8, uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_sub_uint16';
+CREATE FUNCTION uint8_mul_int1(uint8, int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_int1';
+CREATE FUNCTION uint8_mul_int2(uint8, int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_int2';
+CREATE FUNCTION uint8_mul_int4(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_int4';
+CREATE FUNCTION uint8_mul_int8(uint8, int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_int8';
+CREATE FUNCTION uint8_mul_int16(uint8, int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_int16';
+CREATE FUNCTION uint8_mul_uint1(uint8, uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_uint1';
+CREATE FUNCTION uint8_mul_uint2(uint8, uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_uint2';
+CREATE FUNCTION uint8_mul_uint4(uint8, uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_uint4';
+CREATE FUNCTION uint8_mul_uint16(uint8, uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mul_uint16';
+CREATE FUNCTION uint8_div_int1(uint8, int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_int1';
+CREATE FUNCTION uint8_div_int2(uint8, int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_int2';
+CREATE FUNCTION uint8_div_int4(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_int4';
+CREATE FUNCTION uint8_div_int8(uint8, int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_int8';
+CREATE FUNCTION uint8_div_int16(uint8, int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_int16';
+CREATE FUNCTION uint8_div_uint1(uint8, uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_uint1';
+CREATE FUNCTION uint8_div_uint2(uint8, uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_uint2';
+CREATE FUNCTION uint8_div_uint4(uint8, uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_uint4';
+CREATE FUNCTION uint8_div_uint16(uint8, uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_div_uint16';
+CREATE FUNCTION uint8_mod_int1(uint8, int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_int1';
+CREATE FUNCTION uint8_mod_int2(uint8, int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_int2';
+CREATE FUNCTION uint8_mod_int4(uint8, int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_int4';
+CREATE FUNCTION uint8_mod_int8(uint8, int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_int8';
+CREATE FUNCTION uint8_mod_int16(uint8, int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_int16';
+CREATE FUNCTION uint8_mod_uint1(uint8, uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_uint1';
+CREATE FUNCTION uint8_mod_uint2(uint8, uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_uint2';
+CREATE FUNCTION uint8_mod_uint4(uint8, uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_uint4';
+CREATE FUNCTION uint8_mod_uint16(uint8, uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=int1,
+    PROCEDURE=uint8_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=int2,
+    PROCEDURE=uint8_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=int4,
+    PROCEDURE=uint8_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=int8,
+    PROCEDURE=uint8_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=int16,
+    PROCEDURE=uint8_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=uint1,
+    PROCEDURE=uint8_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=uint2,
+    PROCEDURE=uint8_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=uint4,
+    PROCEDURE=uint8_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint8,
+    RIGHTARG=uint16,
+    PROCEDURE=uint8_mod_uint16
+);
+
+
+
+-- Cross-type operators for uint16
+
+CREATE FUNCTION uint16_eq_int1(uint16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_int1';
+CREATE FUNCTION uint16_eq_int2(uint16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_int2';
+CREATE FUNCTION uint16_eq_int4(uint16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_int4';
+CREATE FUNCTION uint16_eq_int8(uint16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_int8';
+CREATE FUNCTION uint16_eq_int16(uint16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_int16';
+CREATE FUNCTION uint16_eq_uint1(uint16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_uint1';
+CREATE FUNCTION uint16_eq_uint2(uint16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_uint2';
+CREATE FUNCTION uint16_eq_uint4(uint16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_uint4';
+CREATE FUNCTION uint16_eq_uint8(uint16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_eq_uint8';
+CREATE FUNCTION uint16_ne_int1(uint16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_int1';
+CREATE FUNCTION uint16_ne_int2(uint16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_int2';
+CREATE FUNCTION uint16_ne_int4(uint16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_int4';
+CREATE FUNCTION uint16_ne_int8(uint16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_int8';
+CREATE FUNCTION uint16_ne_int16(uint16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_int16';
+CREATE FUNCTION uint16_ne_uint1(uint16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_uint1';
+CREATE FUNCTION uint16_ne_uint2(uint16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_uint2';
+CREATE FUNCTION uint16_ne_uint4(uint16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_uint4';
+CREATE FUNCTION uint16_ne_uint8(uint16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ne_uint8';
+CREATE FUNCTION uint16_gt_int1(uint16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_int1';
+CREATE FUNCTION uint16_gt_int2(uint16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_int2';
+CREATE FUNCTION uint16_gt_int4(uint16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_int4';
+CREATE FUNCTION uint16_gt_int8(uint16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_int8';
+CREATE FUNCTION uint16_gt_int16(uint16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_int16';
+CREATE FUNCTION uint16_gt_uint1(uint16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_uint1';
+CREATE FUNCTION uint16_gt_uint2(uint16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_uint2';
+CREATE FUNCTION uint16_gt_uint4(uint16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_uint4';
+CREATE FUNCTION uint16_gt_uint8(uint16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_gt_uint8';
+CREATE FUNCTION uint16_lt_int1(uint16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_int1';
+CREATE FUNCTION uint16_lt_int2(uint16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_int2';
+CREATE FUNCTION uint16_lt_int4(uint16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_int4';
+CREATE FUNCTION uint16_lt_int8(uint16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_int8';
+CREATE FUNCTION uint16_lt_int16(uint16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_int16';
+CREATE FUNCTION uint16_lt_uint1(uint16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_uint1';
+CREATE FUNCTION uint16_lt_uint2(uint16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_uint2';
+CREATE FUNCTION uint16_lt_uint4(uint16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_uint4';
+CREATE FUNCTION uint16_lt_uint8(uint16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_lt_uint8';
+CREATE FUNCTION uint16_ge_int1(uint16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_int1';
+CREATE FUNCTION uint16_ge_int2(uint16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_int2';
+CREATE FUNCTION uint16_ge_int4(uint16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_int4';
+CREATE FUNCTION uint16_ge_int8(uint16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_int8';
+CREATE FUNCTION uint16_ge_int16(uint16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_int16';
+CREATE FUNCTION uint16_ge_uint1(uint16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_uint1';
+CREATE FUNCTION uint16_ge_uint2(uint16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_uint2';
+CREATE FUNCTION uint16_ge_uint4(uint16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_uint4';
+CREATE FUNCTION uint16_ge_uint8(uint16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_ge_uint8';
+CREATE FUNCTION uint16_le_int1(uint16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_int1';
+CREATE FUNCTION uint16_le_int2(uint16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_int2';
+CREATE FUNCTION uint16_le_int4(uint16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_int4';
+CREATE FUNCTION uint16_le_int8(uint16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_int8';
+CREATE FUNCTION uint16_le_int16(uint16, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_int16';
+CREATE FUNCTION uint16_le_uint1(uint16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_uint1';
+CREATE FUNCTION uint16_le_uint2(uint16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_uint2';
+CREATE FUNCTION uint16_le_uint4(uint16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_uint4';
+CREATE FUNCTION uint16_le_uint8(uint16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_le_uint8';
+CREATE FUNCTION uint16_add_int1(uint16, int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_int1';
+CREATE FUNCTION uint16_add_int2(uint16, int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_int2';
+CREATE FUNCTION uint16_add_int4(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_int4';
+CREATE FUNCTION uint16_add_int8(uint16, int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_int8';
+CREATE FUNCTION uint16_add_int16(uint16, int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_int16';
+CREATE FUNCTION uint16_add_uint1(uint16, uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_uint1';
+CREATE FUNCTION uint16_add_uint2(uint16, uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_uint2';
+CREATE FUNCTION uint16_add_uint4(uint16, uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_uint4';
+CREATE FUNCTION uint16_add_uint8(uint16, uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_add_uint8';
+CREATE FUNCTION uint16_sub_int1(uint16, int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_int1';
+CREATE FUNCTION uint16_sub_int2(uint16, int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_int2';
+CREATE FUNCTION uint16_sub_int4(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_int4';
+CREATE FUNCTION uint16_sub_int8(uint16, int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_int8';
+CREATE FUNCTION uint16_sub_int16(uint16, int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_int16';
+CREATE FUNCTION uint16_sub_uint1(uint16, uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_uint1';
+CREATE FUNCTION uint16_sub_uint2(uint16, uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_uint2';
+CREATE FUNCTION uint16_sub_uint4(uint16, uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_uint4';
+CREATE FUNCTION uint16_sub_uint8(uint16, uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_sub_uint8';
+CREATE FUNCTION uint16_mul_int1(uint16, int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_int1';
+CREATE FUNCTION uint16_mul_int2(uint16, int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_int2';
+CREATE FUNCTION uint16_mul_int4(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_int4';
+CREATE FUNCTION uint16_mul_int8(uint16, int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_int8';
+CREATE FUNCTION uint16_mul_int16(uint16, int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_int16';
+CREATE FUNCTION uint16_mul_uint1(uint16, uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_uint1';
+CREATE FUNCTION uint16_mul_uint2(uint16, uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_uint2';
+CREATE FUNCTION uint16_mul_uint4(uint16, uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_uint4';
+CREATE FUNCTION uint16_mul_uint8(uint16, uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mul_uint8';
+CREATE FUNCTION uint16_div_int1(uint16, int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_int1';
+CREATE FUNCTION uint16_div_int2(uint16, int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_int2';
+CREATE FUNCTION uint16_div_int4(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_int4';
+CREATE FUNCTION uint16_div_int8(uint16, int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_int8';
+CREATE FUNCTION uint16_div_int16(uint16, int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_int16';
+CREATE FUNCTION uint16_div_uint1(uint16, uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_uint1';
+CREATE FUNCTION uint16_div_uint2(uint16, uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_uint2';
+CREATE FUNCTION uint16_div_uint4(uint16, uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_uint4';
+CREATE FUNCTION uint16_div_uint8(uint16, uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_div_uint8';
+CREATE FUNCTION uint16_mod_int1(uint16, int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_int1';
+CREATE FUNCTION uint16_mod_int2(uint16, int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_int2';
+CREATE FUNCTION uint16_mod_int4(uint16, int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_int4';
+CREATE FUNCTION uint16_mod_int8(uint16, int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_int8';
+CREATE FUNCTION uint16_mod_int16(uint16, int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_int16';
+CREATE FUNCTION uint16_mod_uint1(uint16, uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_uint1';
+CREATE FUNCTION uint16_mod_uint2(uint16, uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_uint2';
+CREATE FUNCTION uint16_mod_uint4(uint16, uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_uint4';
+CREATE FUNCTION uint16_mod_uint8(uint16, uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_mod_uint8';
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_mul_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_div_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=int1,
+    PROCEDURE=uint16_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=int2,
+    PROCEDURE=uint16_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=int4,
+    PROCEDURE=uint16_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=int8,
+    PROCEDURE=uint16_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=int16,
+    PROCEDURE=uint16_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=uint1,
+    PROCEDURE=uint16_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=uint2,
+    PROCEDURE=uint16_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=uint4,
+    PROCEDURE=uint16_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=uint16,
+    RIGHTARG=uint8,
+    PROCEDURE=uint16_mod_uint8
+);
+
+
+
+-- Cross-type operators for int1
+
+CREATE FUNCTION int1_eq_int2(int1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_int2';
+CREATE FUNCTION int1_eq_int4(int1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_int4';
+CREATE FUNCTION int1_eq_int8(int1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_int8';
+CREATE FUNCTION int1_eq_int16(int1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_int16';
+CREATE FUNCTION int1_eq_uint1(int1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_uint1';
+CREATE FUNCTION int1_eq_uint2(int1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_uint2';
+CREATE FUNCTION int1_eq_uint4(int1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_uint4';
+CREATE FUNCTION int1_eq_uint8(int1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_uint8';
+CREATE FUNCTION int1_eq_uint16(int1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_eq_uint16';
+CREATE FUNCTION int1_ne_int2(int1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_int2';
+CREATE FUNCTION int1_ne_int4(int1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_int4';
+CREATE FUNCTION int1_ne_int8(int1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_int8';
+CREATE FUNCTION int1_ne_int16(int1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_int16';
+CREATE FUNCTION int1_ne_uint1(int1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_uint1';
+CREATE FUNCTION int1_ne_uint2(int1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_uint2';
+CREATE FUNCTION int1_ne_uint4(int1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_uint4';
+CREATE FUNCTION int1_ne_uint8(int1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_uint8';
+CREATE FUNCTION int1_ne_uint16(int1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ne_uint16';
+CREATE FUNCTION int1_gt_int2(int1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_int2';
+CREATE FUNCTION int1_gt_int4(int1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_int4';
+CREATE FUNCTION int1_gt_int8(int1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_int8';
+CREATE FUNCTION int1_gt_int16(int1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_int16';
+CREATE FUNCTION int1_gt_uint1(int1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_uint1';
+CREATE FUNCTION int1_gt_uint2(int1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_uint2';
+CREATE FUNCTION int1_gt_uint4(int1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_uint4';
+CREATE FUNCTION int1_gt_uint8(int1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_uint8';
+CREATE FUNCTION int1_gt_uint16(int1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_gt_uint16';
+CREATE FUNCTION int1_lt_int2(int1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_int2';
+CREATE FUNCTION int1_lt_int4(int1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_int4';
+CREATE FUNCTION int1_lt_int8(int1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_int8';
+CREATE FUNCTION int1_lt_int16(int1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_int16';
+CREATE FUNCTION int1_lt_uint1(int1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_uint1';
+CREATE FUNCTION int1_lt_uint2(int1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_uint2';
+CREATE FUNCTION int1_lt_uint4(int1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_uint4';
+CREATE FUNCTION int1_lt_uint8(int1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_uint8';
+CREATE FUNCTION int1_lt_uint16(int1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_lt_uint16';
+CREATE FUNCTION int1_ge_int2(int1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_int2';
+CREATE FUNCTION int1_ge_int4(int1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_int4';
+CREATE FUNCTION int1_ge_int8(int1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_int8';
+CREATE FUNCTION int1_ge_int16(int1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_int16';
+CREATE FUNCTION int1_ge_uint1(int1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_uint1';
+CREATE FUNCTION int1_ge_uint2(int1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_uint2';
+CREATE FUNCTION int1_ge_uint4(int1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_uint4';
+CREATE FUNCTION int1_ge_uint8(int1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_uint8';
+CREATE FUNCTION int1_ge_uint16(int1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_ge_uint16';
+CREATE FUNCTION int1_le_int2(int1, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_int2';
+CREATE FUNCTION int1_le_int4(int1, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_int4';
+CREATE FUNCTION int1_le_int8(int1, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_int8';
+CREATE FUNCTION int1_le_int16(int1, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_int16';
+CREATE FUNCTION int1_le_uint1(int1, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_uint1';
+CREATE FUNCTION int1_le_uint2(int1, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_uint2';
+CREATE FUNCTION int1_le_uint4(int1, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_uint4';
+CREATE FUNCTION int1_le_uint8(int1, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_uint8';
+CREATE FUNCTION int1_le_uint16(int1, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_le_uint16';
+CREATE FUNCTION int1_add_int2(int1, int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_int2';
+CREATE FUNCTION int1_add_int4(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_int4';
+CREATE FUNCTION int1_add_int8(int1, int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_int8';
+CREATE FUNCTION int1_add_int16(int1, int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_int16';
+CREATE FUNCTION int1_add_uint1(int1, uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_uint1';
+CREATE FUNCTION int1_add_uint2(int1, uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_uint2';
+CREATE FUNCTION int1_add_uint4(int1, uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_uint4';
+CREATE FUNCTION int1_add_uint8(int1, uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_uint8';
+CREATE FUNCTION int1_add_uint16(int1, uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_add_uint16';
+CREATE FUNCTION int1_sub_int2(int1, int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_int2';
+CREATE FUNCTION int1_sub_int4(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_int4';
+CREATE FUNCTION int1_sub_int8(int1, int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_int8';
+CREATE FUNCTION int1_sub_int16(int1, int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_int16';
+CREATE FUNCTION int1_sub_uint1(int1, uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_uint1';
+CREATE FUNCTION int1_sub_uint2(int1, uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_uint2';
+CREATE FUNCTION int1_sub_uint4(int1, uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_uint4';
+CREATE FUNCTION int1_sub_uint8(int1, uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_uint8';
+CREATE FUNCTION int1_sub_uint16(int1, uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_sub_uint16';
+CREATE FUNCTION int1_mul_int2(int1, int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_int2';
+CREATE FUNCTION int1_mul_int4(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_int4';
+CREATE FUNCTION int1_mul_int8(int1, int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_int8';
+CREATE FUNCTION int1_mul_int16(int1, int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_int16';
+CREATE FUNCTION int1_mul_uint1(int1, uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_uint1';
+CREATE FUNCTION int1_mul_uint2(int1, uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_uint2';
+CREATE FUNCTION int1_mul_uint4(int1, uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_uint4';
+CREATE FUNCTION int1_mul_uint8(int1, uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_uint8';
+CREATE FUNCTION int1_mul_uint16(int1, uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mul_uint16';
+CREATE FUNCTION int1_div_int2(int1, int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_int2';
+CREATE FUNCTION int1_div_int4(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_int4';
+CREATE FUNCTION int1_div_int8(int1, int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_int8';
+CREATE FUNCTION int1_div_int16(int1, int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_int16';
+CREATE FUNCTION int1_div_uint1(int1, uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_uint1';
+CREATE FUNCTION int1_div_uint2(int1, uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_uint2';
+CREATE FUNCTION int1_div_uint4(int1, uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_uint4';
+CREATE FUNCTION int1_div_uint8(int1, uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_uint8';
+CREATE FUNCTION int1_div_uint16(int1, uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_div_uint16';
+CREATE FUNCTION int1_mod_int2(int1, int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_int2';
+CREATE FUNCTION int1_mod_int4(int1, int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_int4';
+CREATE FUNCTION int1_mod_int8(int1, int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_int8';
+CREATE FUNCTION int1_mod_int16(int1, int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_int16';
+CREATE FUNCTION int1_mod_uint1(int1, uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_uint1';
+CREATE FUNCTION int1_mod_uint2(int1, uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_uint2';
+CREATE FUNCTION int1_mod_uint4(int1, uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_uint4';
+CREATE FUNCTION int1_mod_uint8(int1, uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_uint8';
+CREATE FUNCTION int1_mod_uint16(int1, uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=int2,
+    PROCEDURE=int1_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=int4,
+    PROCEDURE=int1_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=int8,
+    PROCEDURE=int1_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=int16,
+    PROCEDURE=int1_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=uint1,
+    PROCEDURE=int1_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=uint2,
+    PROCEDURE=int1_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=uint4,
+    PROCEDURE=int1_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=uint8,
+    PROCEDURE=int1_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int1,
+    RIGHTARG=uint16,
+    PROCEDURE=int1_mod_uint16
+);
+
+
+
+-- Cross-type operators for int2
+
+CREATE FUNCTION int2_eq_int1(int2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_int1';
+CREATE FUNCTION int2_eq_int16(int2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_int16';
+CREATE FUNCTION int2_eq_uint1(int2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_uint1';
+CREATE FUNCTION int2_eq_uint2(int2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_uint2';
+CREATE FUNCTION int2_eq_uint4(int2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_uint4';
+CREATE FUNCTION int2_eq_uint8(int2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_uint8';
+CREATE FUNCTION int2_eq_uint16(int2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_eq_uint16';
+CREATE FUNCTION int2_ne_int1(int2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_int1';
+CREATE FUNCTION int2_ne_int16(int2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_int16';
+CREATE FUNCTION int2_ne_uint1(int2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_uint1';
+CREATE FUNCTION int2_ne_uint2(int2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_uint2';
+CREATE FUNCTION int2_ne_uint4(int2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_uint4';
+CREATE FUNCTION int2_ne_uint8(int2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_uint8';
+CREATE FUNCTION int2_ne_uint16(int2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ne_uint16';
+CREATE FUNCTION int2_gt_int1(int2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_int1';
+CREATE FUNCTION int2_gt_int16(int2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_int16';
+CREATE FUNCTION int2_gt_uint1(int2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_uint1';
+CREATE FUNCTION int2_gt_uint2(int2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_uint2';
+CREATE FUNCTION int2_gt_uint4(int2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_uint4';
+CREATE FUNCTION int2_gt_uint8(int2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_uint8';
+CREATE FUNCTION int2_gt_uint16(int2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_gt_uint16';
+CREATE FUNCTION int2_lt_int1(int2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_int1';
+CREATE FUNCTION int2_lt_int16(int2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_int16';
+CREATE FUNCTION int2_lt_uint1(int2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_uint1';
+CREATE FUNCTION int2_lt_uint2(int2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_uint2';
+CREATE FUNCTION int2_lt_uint4(int2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_uint4';
+CREATE FUNCTION int2_lt_uint8(int2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_uint8';
+CREATE FUNCTION int2_lt_uint16(int2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_lt_uint16';
+CREATE FUNCTION int2_ge_int1(int2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_int1';
+CREATE FUNCTION int2_ge_int16(int2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_int16';
+CREATE FUNCTION int2_ge_uint1(int2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_uint1';
+CREATE FUNCTION int2_ge_uint2(int2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_uint2';
+CREATE FUNCTION int2_ge_uint4(int2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_uint4';
+CREATE FUNCTION int2_ge_uint8(int2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_uint8';
+CREATE FUNCTION int2_ge_uint16(int2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_ge_uint16';
+CREATE FUNCTION int2_le_int1(int2, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_int1';
+CREATE FUNCTION int2_le_int16(int2, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_int16';
+CREATE FUNCTION int2_le_uint1(int2, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_uint1';
+CREATE FUNCTION int2_le_uint2(int2, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_uint2';
+CREATE FUNCTION int2_le_uint4(int2, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_uint4';
+CREATE FUNCTION int2_le_uint8(int2, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_uint8';
+CREATE FUNCTION int2_le_uint16(int2, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_le_uint16';
+CREATE FUNCTION int2_add_int1(int2, int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_int1';
+CREATE FUNCTION int2_add_int16(int2, int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_int16';
+CREATE FUNCTION int2_add_uint1(int2, uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_uint1';
+CREATE FUNCTION int2_add_uint2(int2, uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_uint2';
+CREATE FUNCTION int2_add_uint4(int2, uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_uint4';
+CREATE FUNCTION int2_add_uint8(int2, uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_uint8';
+CREATE FUNCTION int2_add_uint16(int2, uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_add_uint16';
+CREATE FUNCTION int2_sub_int1(int2, int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_int1';
+CREATE FUNCTION int2_sub_int16(int2, int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_int16';
+CREATE FUNCTION int2_sub_uint1(int2, uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_uint1';
+CREATE FUNCTION int2_sub_uint2(int2, uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_uint2';
+CREATE FUNCTION int2_sub_uint4(int2, uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_uint4';
+CREATE FUNCTION int2_sub_uint8(int2, uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_uint8';
+CREATE FUNCTION int2_sub_uint16(int2, uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_sub_uint16';
+CREATE FUNCTION int2_mul_int1(int2, int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_int1';
+CREATE FUNCTION int2_mul_int16(int2, int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_int16';
+CREATE FUNCTION int2_mul_uint1(int2, uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_uint1';
+CREATE FUNCTION int2_mul_uint2(int2, uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_uint2';
+CREATE FUNCTION int2_mul_uint4(int2, uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_uint4';
+CREATE FUNCTION int2_mul_uint8(int2, uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_uint8';
+CREATE FUNCTION int2_mul_uint16(int2, uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mul_uint16';
+CREATE FUNCTION int2_div_int1(int2, int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_int1';
+CREATE FUNCTION int2_div_int16(int2, int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_int16';
+CREATE FUNCTION int2_div_uint1(int2, uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_uint1';
+CREATE FUNCTION int2_div_uint2(int2, uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_uint2';
+CREATE FUNCTION int2_div_uint4(int2, uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_uint4';
+CREATE FUNCTION int2_div_uint8(int2, uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_uint8';
+CREATE FUNCTION int2_div_uint16(int2, uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_div_uint16';
+CREATE FUNCTION int2_mod_int1(int2, int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_int1';
+CREATE FUNCTION int2_mod_int16(int2, int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_int16';
+CREATE FUNCTION int2_mod_uint1(int2, uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_uint1';
+CREATE FUNCTION int2_mod_uint2(int2, uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_uint2';
+CREATE FUNCTION int2_mod_uint4(int2, uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_uint4';
+CREATE FUNCTION int2_mod_uint8(int2, uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_uint8';
+CREATE FUNCTION int2_mod_uint16(int2, uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=int1,
+    PROCEDURE=int2_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=int16,
+    PROCEDURE=int2_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=uint1,
+    PROCEDURE=int2_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=uint2,
+    PROCEDURE=int2_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=uint4,
+    PROCEDURE=int2_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=uint8,
+    PROCEDURE=int2_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int2,
+    RIGHTARG=uint16,
+    PROCEDURE=int2_mod_uint16
+);
+
+
+
+-- Cross-type operators for int4
+
+CREATE FUNCTION int4_eq_int1(int4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_int1';
+CREATE FUNCTION int4_eq_int16(int4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_int16';
+CREATE FUNCTION int4_eq_uint1(int4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_uint1';
+CREATE FUNCTION int4_eq_uint2(int4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_uint2';
+CREATE FUNCTION int4_eq_uint4(int4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_uint4';
+CREATE FUNCTION int4_eq_uint8(int4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_uint8';
+CREATE FUNCTION int4_eq_uint16(int4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_eq_uint16';
+CREATE FUNCTION int4_ne_int1(int4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_int1';
+CREATE FUNCTION int4_ne_int16(int4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_int16';
+CREATE FUNCTION int4_ne_uint1(int4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_uint1';
+CREATE FUNCTION int4_ne_uint2(int4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_uint2';
+CREATE FUNCTION int4_ne_uint4(int4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_uint4';
+CREATE FUNCTION int4_ne_uint8(int4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_uint8';
+CREATE FUNCTION int4_ne_uint16(int4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ne_uint16';
+CREATE FUNCTION int4_gt_int1(int4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_int1';
+CREATE FUNCTION int4_gt_int16(int4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_int16';
+CREATE FUNCTION int4_gt_uint1(int4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_uint1';
+CREATE FUNCTION int4_gt_uint2(int4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_uint2';
+CREATE FUNCTION int4_gt_uint4(int4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_uint4';
+CREATE FUNCTION int4_gt_uint8(int4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_uint8';
+CREATE FUNCTION int4_gt_uint16(int4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_gt_uint16';
+CREATE FUNCTION int4_lt_int1(int4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_int1';
+CREATE FUNCTION int4_lt_int16(int4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_int16';
+CREATE FUNCTION int4_lt_uint1(int4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_uint1';
+CREATE FUNCTION int4_lt_uint2(int4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_uint2';
+CREATE FUNCTION int4_lt_uint4(int4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_uint4';
+CREATE FUNCTION int4_lt_uint8(int4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_uint8';
+CREATE FUNCTION int4_lt_uint16(int4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_lt_uint16';
+CREATE FUNCTION int4_ge_int1(int4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_int1';
+CREATE FUNCTION int4_ge_int16(int4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_int16';
+CREATE FUNCTION int4_ge_uint1(int4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_uint1';
+CREATE FUNCTION int4_ge_uint2(int4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_uint2';
+CREATE FUNCTION int4_ge_uint4(int4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_uint4';
+CREATE FUNCTION int4_ge_uint8(int4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_uint8';
+CREATE FUNCTION int4_ge_uint16(int4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_ge_uint16';
+CREATE FUNCTION int4_le_int1(int4, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_int1';
+CREATE FUNCTION int4_le_int16(int4, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_int16';
+CREATE FUNCTION int4_le_uint1(int4, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_uint1';
+CREATE FUNCTION int4_le_uint2(int4, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_uint2';
+CREATE FUNCTION int4_le_uint4(int4, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_uint4';
+CREATE FUNCTION int4_le_uint8(int4, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_uint8';
+CREATE FUNCTION int4_le_uint16(int4, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_le_uint16';
+CREATE FUNCTION int4_add_int1(int4, int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_int1';
+CREATE FUNCTION int4_add_int16(int4, int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_int16';
+CREATE FUNCTION int4_add_uint1(int4, uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_uint1';
+CREATE FUNCTION int4_add_uint2(int4, uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_uint2';
+CREATE FUNCTION int4_add_uint4(int4, uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_uint4';
+CREATE FUNCTION int4_add_uint8(int4, uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_uint8';
+CREATE FUNCTION int4_add_uint16(int4, uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_add_uint16';
+CREATE FUNCTION int4_sub_int1(int4, int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_int1';
+CREATE FUNCTION int4_sub_int16(int4, int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_int16';
+CREATE FUNCTION int4_sub_uint1(int4, uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_uint1';
+CREATE FUNCTION int4_sub_uint2(int4, uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_uint2';
+CREATE FUNCTION int4_sub_uint4(int4, uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_uint4';
+CREATE FUNCTION int4_sub_uint8(int4, uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_uint8';
+CREATE FUNCTION int4_sub_uint16(int4, uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_sub_uint16';
+CREATE FUNCTION int4_mul_int1(int4, int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_int1';
+CREATE FUNCTION int4_mul_int16(int4, int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_int16';
+CREATE FUNCTION int4_mul_uint1(int4, uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_uint1';
+CREATE FUNCTION int4_mul_uint2(int4, uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_uint2';
+CREATE FUNCTION int4_mul_uint4(int4, uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_uint4';
+CREATE FUNCTION int4_mul_uint8(int4, uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_uint8';
+CREATE FUNCTION int4_mul_uint16(int4, uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mul_uint16';
+CREATE FUNCTION int4_div_int1(int4, int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_int1';
+CREATE FUNCTION int4_div_int16(int4, int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_int16';
+CREATE FUNCTION int4_div_uint1(int4, uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_uint1';
+CREATE FUNCTION int4_div_uint2(int4, uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_uint2';
+CREATE FUNCTION int4_div_uint4(int4, uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_uint4';
+CREATE FUNCTION int4_div_uint8(int4, uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_uint8';
+CREATE FUNCTION int4_div_uint16(int4, uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_div_uint16';
+CREATE FUNCTION int4_mod_int1(int4, int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_int1';
+CREATE FUNCTION int4_mod_int16(int4, int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_int16';
+CREATE FUNCTION int4_mod_uint1(int4, uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_uint1';
+CREATE FUNCTION int4_mod_uint2(int4, uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_uint2';
+CREATE FUNCTION int4_mod_uint4(int4, uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_uint4';
+CREATE FUNCTION int4_mod_uint8(int4, uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_uint8';
+CREATE FUNCTION int4_mod_uint16(int4, uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=int1,
+    PROCEDURE=int4_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=int16,
+    PROCEDURE=int4_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=uint1,
+    PROCEDURE=int4_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=uint2,
+    PROCEDURE=int4_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=uint4,
+    PROCEDURE=int4_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=uint8,
+    PROCEDURE=int4_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int4,
+    RIGHTARG=uint16,
+    PROCEDURE=int4_mod_uint16
+);
+
+
+
+-- Cross-type operators for int8
+
+CREATE FUNCTION int8_eq_int1(int8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_int1';
+CREATE FUNCTION int8_eq_int16(int8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_int16';
+CREATE FUNCTION int8_eq_uint1(int8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_uint1';
+CREATE FUNCTION int8_eq_uint2(int8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_uint2';
+CREATE FUNCTION int8_eq_uint4(int8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_uint4';
+CREATE FUNCTION int8_eq_uint8(int8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_uint8';
+CREATE FUNCTION int8_eq_uint16(int8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_eq_uint16';
+CREATE FUNCTION int8_ne_int1(int8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_int1';
+CREATE FUNCTION int8_ne_int16(int8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_int16';
+CREATE FUNCTION int8_ne_uint1(int8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_uint1';
+CREATE FUNCTION int8_ne_uint2(int8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_uint2';
+CREATE FUNCTION int8_ne_uint4(int8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_uint4';
+CREATE FUNCTION int8_ne_uint8(int8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_uint8';
+CREATE FUNCTION int8_ne_uint16(int8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ne_uint16';
+CREATE FUNCTION int8_gt_int1(int8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_int1';
+CREATE FUNCTION int8_gt_int16(int8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_int16';
+CREATE FUNCTION int8_gt_uint1(int8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_uint1';
+CREATE FUNCTION int8_gt_uint2(int8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_uint2';
+CREATE FUNCTION int8_gt_uint4(int8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_uint4';
+CREATE FUNCTION int8_gt_uint8(int8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_uint8';
+CREATE FUNCTION int8_gt_uint16(int8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_gt_uint16';
+CREATE FUNCTION int8_lt_int1(int8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_int1';
+CREATE FUNCTION int8_lt_int16(int8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_int16';
+CREATE FUNCTION int8_lt_uint1(int8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_uint1';
+CREATE FUNCTION int8_lt_uint2(int8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_uint2';
+CREATE FUNCTION int8_lt_uint4(int8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_uint4';
+CREATE FUNCTION int8_lt_uint8(int8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_uint8';
+CREATE FUNCTION int8_lt_uint16(int8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_lt_uint16';
+CREATE FUNCTION int8_ge_int1(int8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_int1';
+CREATE FUNCTION int8_ge_int16(int8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_int16';
+CREATE FUNCTION int8_ge_uint1(int8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_uint1';
+CREATE FUNCTION int8_ge_uint2(int8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_uint2';
+CREATE FUNCTION int8_ge_uint4(int8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_uint4';
+CREATE FUNCTION int8_ge_uint8(int8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_uint8';
+CREATE FUNCTION int8_ge_uint16(int8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_ge_uint16';
+CREATE FUNCTION int8_le_int1(int8, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_int1';
+CREATE FUNCTION int8_le_int16(int8, int16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_int16';
+CREATE FUNCTION int8_le_uint1(int8, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_uint1';
+CREATE FUNCTION int8_le_uint2(int8, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_uint2';
+CREATE FUNCTION int8_le_uint4(int8, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_uint4';
+CREATE FUNCTION int8_le_uint8(int8, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_uint8';
+CREATE FUNCTION int8_le_uint16(int8, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_le_uint16';
+CREATE FUNCTION int8_add_int1(int8, int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_int1';
+CREATE FUNCTION int8_add_int16(int8, int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_int16';
+CREATE FUNCTION int8_add_uint1(int8, uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_uint1';
+CREATE FUNCTION int8_add_uint2(int8, uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_uint2';
+CREATE FUNCTION int8_add_uint4(int8, uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_uint4';
+CREATE FUNCTION int8_add_uint8(int8, uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_uint8';
+CREATE FUNCTION int8_add_uint16(int8, uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_add_uint16';
+CREATE FUNCTION int8_sub_int1(int8, int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_int1';
+CREATE FUNCTION int8_sub_int16(int8, int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_int16';
+CREATE FUNCTION int8_sub_uint1(int8, uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_uint1';
+CREATE FUNCTION int8_sub_uint2(int8, uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_uint2';
+CREATE FUNCTION int8_sub_uint4(int8, uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_uint4';
+CREATE FUNCTION int8_sub_uint8(int8, uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_uint8';
+CREATE FUNCTION int8_sub_uint16(int8, uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_sub_uint16';
+CREATE FUNCTION int8_mul_int1(int8, int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_int1';
+CREATE FUNCTION int8_mul_int16(int8, int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_int16';
+CREATE FUNCTION int8_mul_uint1(int8, uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_uint1';
+CREATE FUNCTION int8_mul_uint2(int8, uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_uint2';
+CREATE FUNCTION int8_mul_uint4(int8, uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_uint4';
+CREATE FUNCTION int8_mul_uint8(int8, uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_uint8';
+CREATE FUNCTION int8_mul_uint16(int8, uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mul_uint16';
+CREATE FUNCTION int8_div_int1(int8, int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_int1';
+CREATE FUNCTION int8_div_int16(int8, int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_int16';
+CREATE FUNCTION int8_div_uint1(int8, uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_uint1';
+CREATE FUNCTION int8_div_uint2(int8, uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_uint2';
+CREATE FUNCTION int8_div_uint4(int8, uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_uint4';
+CREATE FUNCTION int8_div_uint8(int8, uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_uint8';
+CREATE FUNCTION int8_div_uint16(int8, uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_div_uint16';
+CREATE FUNCTION int8_mod_int1(int8, int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_int1';
+CREATE FUNCTION int8_mod_int16(int8, int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_int16';
+CREATE FUNCTION int8_mod_uint1(int8, uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_uint1';
+CREATE FUNCTION int8_mod_uint2(int8, uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_uint2';
+CREATE FUNCTION int8_mod_uint4(int8, uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_uint4';
+CREATE FUNCTION int8_mod_uint8(int8, uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_uint8';
+CREATE FUNCTION int8_mod_uint16(int8, uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_eq_int16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_ne_int16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_gt_int16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_lt_int16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_ge_int16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_le_int16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_add_int16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_sub_int16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_mul_int16
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_div_int16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=int1,
+    PROCEDURE=int8_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=int16,
+    PROCEDURE=int8_mod_int16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=uint1,
+    PROCEDURE=int8_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=uint2,
+    PROCEDURE=int8_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=uint4,
+    PROCEDURE=int8_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=uint8,
+    PROCEDURE=int8_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int8,
+    RIGHTARG=uint16,
+    PROCEDURE=int8_mod_uint16
+);
+
+
+
+-- Cross-type operators for int16
+
+CREATE FUNCTION int16_eq_int1(int16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_int1';
+CREATE FUNCTION int16_eq_int2(int16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_int2';
+CREATE FUNCTION int16_eq_int4(int16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_int4';
+CREATE FUNCTION int16_eq_int8(int16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_int8';
+CREATE FUNCTION int16_eq_uint1(int16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_uint1';
+CREATE FUNCTION int16_eq_uint2(int16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_uint2';
+CREATE FUNCTION int16_eq_uint4(int16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_uint4';
+CREATE FUNCTION int16_eq_uint8(int16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_uint8';
+CREATE FUNCTION int16_eq_uint16(int16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_eq_uint16';
+CREATE FUNCTION int16_ne_int1(int16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_int1';
+CREATE FUNCTION int16_ne_int2(int16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_int2';
+CREATE FUNCTION int16_ne_int4(int16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_int4';
+CREATE FUNCTION int16_ne_int8(int16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_int8';
+CREATE FUNCTION int16_ne_uint1(int16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_uint1';
+CREATE FUNCTION int16_ne_uint2(int16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_uint2';
+CREATE FUNCTION int16_ne_uint4(int16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_uint4';
+CREATE FUNCTION int16_ne_uint8(int16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_uint8';
+CREATE FUNCTION int16_ne_uint16(int16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ne_uint16';
+CREATE FUNCTION int16_gt_int1(int16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_int1';
+CREATE FUNCTION int16_gt_int2(int16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_int2';
+CREATE FUNCTION int16_gt_int4(int16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_int4';
+CREATE FUNCTION int16_gt_int8(int16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_int8';
+CREATE FUNCTION int16_gt_uint1(int16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_uint1';
+CREATE FUNCTION int16_gt_uint2(int16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_uint2';
+CREATE FUNCTION int16_gt_uint4(int16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_uint4';
+CREATE FUNCTION int16_gt_uint8(int16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_uint8';
+CREATE FUNCTION int16_gt_uint16(int16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_gt_uint16';
+CREATE FUNCTION int16_lt_int1(int16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_int1';
+CREATE FUNCTION int16_lt_int2(int16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_int2';
+CREATE FUNCTION int16_lt_int4(int16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_int4';
+CREATE FUNCTION int16_lt_int8(int16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_int8';
+CREATE FUNCTION int16_lt_uint1(int16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_uint1';
+CREATE FUNCTION int16_lt_uint2(int16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_uint2';
+CREATE FUNCTION int16_lt_uint4(int16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_uint4';
+CREATE FUNCTION int16_lt_uint8(int16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_uint8';
+CREATE FUNCTION int16_lt_uint16(int16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_lt_uint16';
+CREATE FUNCTION int16_ge_int1(int16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_int1';
+CREATE FUNCTION int16_ge_int2(int16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_int2';
+CREATE FUNCTION int16_ge_int4(int16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_int4';
+CREATE FUNCTION int16_ge_int8(int16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_int8';
+CREATE FUNCTION int16_ge_uint1(int16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_uint1';
+CREATE FUNCTION int16_ge_uint2(int16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_uint2';
+CREATE FUNCTION int16_ge_uint4(int16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_uint4';
+CREATE FUNCTION int16_ge_uint8(int16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_uint8';
+CREATE FUNCTION int16_ge_uint16(int16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_ge_uint16';
+CREATE FUNCTION int16_le_int1(int16, int1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_int1';
+CREATE FUNCTION int16_le_int2(int16, int2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_int2';
+CREATE FUNCTION int16_le_int4(int16, int4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_int4';
+CREATE FUNCTION int16_le_int8(int16, int8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_int8';
+CREATE FUNCTION int16_le_uint1(int16, uint1) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_uint1';
+CREATE FUNCTION int16_le_uint2(int16, uint2) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_uint2';
+CREATE FUNCTION int16_le_uint4(int16, uint4) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_uint4';
+CREATE FUNCTION int16_le_uint8(int16, uint8) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_uint8';
+CREATE FUNCTION int16_le_uint16(int16, uint16) RETURNS boolean
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_le_uint16';
+CREATE FUNCTION int16_add_int1(int16, int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_int1';
+CREATE FUNCTION int16_add_int2(int16, int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_int2';
+CREATE FUNCTION int16_add_int4(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_int4';
+CREATE FUNCTION int16_add_int8(int16, int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_int8';
+CREATE FUNCTION int16_add_uint1(int16, uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_uint1';
+CREATE FUNCTION int16_add_uint2(int16, uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_uint2';
+CREATE FUNCTION int16_add_uint4(int16, uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_uint4';
+CREATE FUNCTION int16_add_uint8(int16, uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_uint8';
+CREATE FUNCTION int16_add_uint16(int16, uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_add_uint16';
+CREATE FUNCTION int16_sub_int1(int16, int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_int1';
+CREATE FUNCTION int16_sub_int2(int16, int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_int2';
+CREATE FUNCTION int16_sub_int4(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_int4';
+CREATE FUNCTION int16_sub_int8(int16, int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_int8';
+CREATE FUNCTION int16_sub_uint1(int16, uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_uint1';
+CREATE FUNCTION int16_sub_uint2(int16, uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_uint2';
+CREATE FUNCTION int16_sub_uint4(int16, uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_uint4';
+CREATE FUNCTION int16_sub_uint8(int16, uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_uint8';
+CREATE FUNCTION int16_sub_uint16(int16, uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_sub_uint16';
+CREATE FUNCTION int16_mul_int1(int16, int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_int1';
+CREATE FUNCTION int16_mul_int2(int16, int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_int2';
+CREATE FUNCTION int16_mul_int4(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_int4';
+CREATE FUNCTION int16_mul_int8(int16, int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_int8';
+CREATE FUNCTION int16_mul_uint1(int16, uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_uint1';
+CREATE FUNCTION int16_mul_uint2(int16, uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_uint2';
+CREATE FUNCTION int16_mul_uint4(int16, uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_uint4';
+CREATE FUNCTION int16_mul_uint8(int16, uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_uint8';
+CREATE FUNCTION int16_mul_uint16(int16, uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mul_uint16';
+CREATE FUNCTION int16_div_int1(int16, int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_int1';
+CREATE FUNCTION int16_div_int2(int16, int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_int2';
+CREATE FUNCTION int16_div_int4(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_int4';
+CREATE FUNCTION int16_div_int8(int16, int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_int8';
+CREATE FUNCTION int16_div_uint1(int16, uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_uint1';
+CREATE FUNCTION int16_div_uint2(int16, uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_uint2';
+CREATE FUNCTION int16_div_uint4(int16, uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_uint4';
+CREATE FUNCTION int16_div_uint8(int16, uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_uint8';
+CREATE FUNCTION int16_div_uint16(int16, uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_div_uint16';
+CREATE FUNCTION int16_mod_int1(int16, int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_int1';
+CREATE FUNCTION int16_mod_int2(int16, int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_int2';
+CREATE FUNCTION int16_mod_int4(int16, int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_int4';
+CREATE FUNCTION int16_mod_int8(int16, int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_int8';
+CREATE FUNCTION int16_mod_uint1(int16, uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_uint1';
+CREATE FUNCTION int16_mod_uint2(int16, uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_uint2';
+CREATE FUNCTION int16_mod_uint4(int16, uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_uint4';
+CREATE FUNCTION int16_mod_uint8(int16, uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_uint8';
+CREATE FUNCTION int16_mod_uint16(int16, uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_mod_uint16';
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_eq_int1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_eq_int2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_eq_int4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_eq_int8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_eq_uint1,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_eq_uint2,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_eq_uint4,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_eq_uint8,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR = (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_eq_uint16,
+    COMMUTATOR = =,
+    NEGATOR = <>,
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_ne_int1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_ne_int2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_ne_int4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_ne_int8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_ne_uint1,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_ne_uint2,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_ne_uint4,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_ne_uint8,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR <> (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_ne_uint16,
+    COMMUTATOR = <>,
+    NEGATOR = =,
+    RESTRICT = neqsel,
+    JOIN = neqjoinsel,
+    HASHES,
+    MERGES
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_gt_int1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_gt_int2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_gt_int4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_gt_int8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_gt_uint1,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_gt_uint2,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_gt_uint4,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_gt_uint8,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR > (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_gt_uint16,
+    COMMUTATOR = >,
+    NEGATOR = <=,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_lt_int1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_lt_int2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_lt_int4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_lt_int8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_lt_uint1,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_lt_uint2,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_lt_uint4,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_lt_uint8,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR < (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_lt_uint16,
+    COMMUTATOR = <,
+    NEGATOR = >=,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_ge_int1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_ge_int2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_ge_int4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_ge_int8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_ge_uint1,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_ge_uint2,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_ge_uint4,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_ge_uint8,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR >= (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_ge_uint16,
+    COMMUTATOR = >=,
+    NEGATOR = <,
+    RESTRICT = scalargtsel,
+    JOIN = scalargtjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_le_int1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_le_int2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_le_int4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_le_int8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_le_uint1,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_le_uint2,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_le_uint4,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_le_uint8,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR <= (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_le_uint16,
+    COMMUTATOR = <=,
+    NEGATOR = >,
+    RESTRICT = scalarltsel,
+    JOIN = scalarltjoinsel
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_add_int1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_add_int2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_add_int4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_add_int8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_add_uint1,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_add_uint2,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_add_uint4,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_add_uint8,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR + (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_add_uint16,
+    COMMUTATOR = +
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_sub_int1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_sub_int2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_sub_int4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_sub_int8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_sub_uint1,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_sub_uint2,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_sub_uint4,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_sub_uint8,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR - (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_sub_uint16,
+    COMMUTATOR = -
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_mul_int1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_mul_int2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_mul_int4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_mul_int8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_mul_uint1
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_mul_uint2
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_mul_uint4
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_mul_uint8
+);
+
+
+CREATE OPERATOR * (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_mul_uint16
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_div_int1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_div_int2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_div_int4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_div_int8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_div_uint1
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_div_uint2
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_div_uint4
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_div_uint8
+);
+
+
+CREATE OPERATOR / (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_div_uint16
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=int1,
+    PROCEDURE=int16_mod_int1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=int2,
+    PROCEDURE=int16_mod_int2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=int4,
+    PROCEDURE=int16_mod_int4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=int8,
+    PROCEDURE=int16_mod_int8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=uint1,
+    PROCEDURE=int16_mod_uint1
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=uint2,
+    PROCEDURE=int16_mod_uint2
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=uint4,
+    PROCEDURE=int16_mod_uint4
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=uint8,
+    PROCEDURE=int16_mod_uint8
+);
+
+
+CREATE OPERATOR % (
+    LEFTARG=int16,
+    RIGHTARG=uint16,
+    PROCEDURE=int16_mod_uint16
+);
+
+
+
+-- Cross-type operators for numeric
+
+
+-- Cross-type operators for float4
+
+
+-- Cross-type operators for float8
+
+
+-- Cross-type operators for json
+
+
+-- Cross-type operators for jsonb
+
+
+-- Cross-type operators for uuid
+
+
+-- Agg ops block
+
+-- Transition function for accumulating uint1
+CREATE FUNCTION uint1_avg_accum(internal, uint1)
+RETURNS internal
+AS '$libdir/uint128', 'uint1_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating uint1
+CREATE FUNCTION uint1_avg_accum_inv(internal, uint1)
+RETURNS internal
+AS '$libdir/uint128', 'uint1_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(uint1) (
+    -- Transition function
+    SFUNC = uint1_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint1_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint1_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(uint1) (
+    -- Transition function
+    SFUNC = uint1_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint1_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint1_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint1_smaller(uint1, uint1)
+RETURNS uint1
+AS '$libdir/uint128', 'uint1_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(uint1) (
+    -- Transition function
+    SFUNC = uint1_smaller,         
+	STYPE = uint1,
+	COMBINEFUNC = uint1_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint1_larger(uint1, uint1)
+RETURNS uint1
+AS '$libdir/uint128', 'uint1_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(uint1) (
+    -- Transition function
+    SFUNC = uint1_larger,         
+	STYPE = uint1,
+	COMBINEFUNC = uint1_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE uint1range;
+
+CREATE OR REPLACE FUNCTION uint1_range_canonical(uint1range)
+RETURNS uint1range
+AS '$libdir/uint128', 'uint1_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION uint1_range_subdiff(uint1, uint1)
+RETURNS double precision
+AS '$libdir/uint128', 'uint1_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE uint1range AS RANGE (
+    SUBTYPE = uint1,
+    SUBTYPE_OPCLASS = uint1_ops,
+    CANONICAL = uint1_range_canonical,
+    SUBTYPE_DIFF = uint1_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_uint1_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_uint1_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(uint1, uint1)
+RETURNS SETOF uint1
+AS '$libdir/uint128', 'generate_series_uint1'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint1_support;
+
+CREATE FUNCTION generate_series(uint1, uint1, uint1)
+RETURNS SETOF uint1
+AS '$libdir/uint128', 'generate_series_step_uint1'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint1_support;
+
+-- Agg ops block
+
+-- Transition function for accumulating uint2
+CREATE FUNCTION uint2_avg_accum(internal, uint2)
+RETURNS internal
+AS '$libdir/uint128', 'uint2_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating uint2
+CREATE FUNCTION uint2_avg_accum_inv(internal, uint2)
+RETURNS internal
+AS '$libdir/uint128', 'uint2_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(uint2) (
+    -- Transition function
+    SFUNC = uint2_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint2_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint2_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(uint2) (
+    -- Transition function
+    SFUNC = uint2_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint2_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint2_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint2_smaller(uint2, uint2)
+RETURNS uint2
+AS '$libdir/uint128', 'uint2_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(uint2) (
+    -- Transition function
+    SFUNC = uint2_smaller,         
+	STYPE = uint2,
+	COMBINEFUNC = uint2_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint2_larger(uint2, uint2)
+RETURNS uint2
+AS '$libdir/uint128', 'uint2_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(uint2) (
+    -- Transition function
+    SFUNC = uint2_larger,         
+	STYPE = uint2,
+	COMBINEFUNC = uint2_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE uint2range;
+
+CREATE OR REPLACE FUNCTION uint2_range_canonical(uint2range)
+RETURNS uint2range
+AS '$libdir/uint128', 'uint2_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION uint2_range_subdiff(uint2, uint2)
+RETURNS double precision
+AS '$libdir/uint128', 'uint2_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE uint2range AS RANGE (
+    SUBTYPE = uint2,
+    SUBTYPE_OPCLASS = uint2_ops,
+    CANONICAL = uint2_range_canonical,
+    SUBTYPE_DIFF = uint2_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_uint2_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_uint2_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(uint2, uint2)
+RETURNS SETOF uint2
+AS '$libdir/uint128', 'generate_series_uint2'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint2_support;
+
+CREATE FUNCTION generate_series(uint2, uint2, uint2)
+RETURNS SETOF uint2
+AS '$libdir/uint128', 'generate_series_step_uint2'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint2_support;
+
+-- Agg ops block
+
+-- Transition function for accumulating uint4
+CREATE FUNCTION uint4_avg_accum(internal, uint4)
+RETURNS internal
+AS '$libdir/uint128', 'uint4_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating uint4
+CREATE FUNCTION uint4_avg_accum_inv(internal, uint4)
+RETURNS internal
+AS '$libdir/uint128', 'uint4_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(uint4) (
+    -- Transition function
+    SFUNC = uint4_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint4_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint4_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(uint4) (
+    -- Transition function
+    SFUNC = uint4_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint4_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint4_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint4_smaller(uint4, uint4)
+RETURNS uint4
+AS '$libdir/uint128', 'uint4_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(uint4) (
+    -- Transition function
+    SFUNC = uint4_smaller,         
+	STYPE = uint4,
+	COMBINEFUNC = uint4_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint4_larger(uint4, uint4)
+RETURNS uint4
+AS '$libdir/uint128', 'uint4_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(uint4) (
+    -- Transition function
+    SFUNC = uint4_larger,         
+	STYPE = uint4,
+	COMBINEFUNC = uint4_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE uint4range;
+
+CREATE OR REPLACE FUNCTION uint4_range_canonical(uint4range)
+RETURNS uint4range
+AS '$libdir/uint128', 'uint4_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION uint4_range_subdiff(uint4, uint4)
+RETURNS double precision
+AS '$libdir/uint128', 'uint4_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE uint4range AS RANGE (
+    SUBTYPE = uint4,
+    SUBTYPE_OPCLASS = uint4_ops,
+    CANONICAL = uint4_range_canonical,
+    SUBTYPE_DIFF = uint4_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_uint4_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_uint4_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(uint4, uint4)
+RETURNS SETOF uint4
+AS '$libdir/uint128', 'generate_series_uint4'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint4_support;
+
+CREATE FUNCTION generate_series(uint4, uint4, uint4)
+RETURNS SETOF uint4
+AS '$libdir/uint128', 'generate_series_step_uint4'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint4_support;
+
+-- Agg ops block
+
+-- Transition function for accumulating uint8
+CREATE FUNCTION uint8_avg_accum(internal, uint8)
+RETURNS internal
+AS '$libdir/uint128', 'uint8_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating uint8
+CREATE FUNCTION uint8_avg_accum_inv(internal, uint8)
+RETURNS internal
+AS '$libdir/uint128', 'uint8_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(uint8) (
+    -- Transition function
+    SFUNC = uint8_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint8_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint8_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(uint8) (
+    -- Transition function
+    SFUNC = uint8_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint8_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint8_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint8_smaller(uint8, uint8)
+RETURNS uint8
+AS '$libdir/uint128', 'uint8_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(uint8) (
+    -- Transition function
+    SFUNC = uint8_smaller,         
+	STYPE = uint8,
+	COMBINEFUNC = uint8_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint8_larger(uint8, uint8)
+RETURNS uint8
+AS '$libdir/uint128', 'uint8_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(uint8) (
+    -- Transition function
+    SFUNC = uint8_larger,         
+	STYPE = uint8,
+	COMBINEFUNC = uint8_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE uint8range;
+
+CREATE OR REPLACE FUNCTION uint8_range_canonical(uint8range)
+RETURNS uint8range
+AS '$libdir/uint128', 'uint8_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION uint8_range_subdiff(uint8, uint8)
+RETURNS double precision
+AS '$libdir/uint128', 'uint8_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE uint8range AS RANGE (
+    SUBTYPE = uint8,
+    SUBTYPE_OPCLASS = uint8_ops,
+    CANONICAL = uint8_range_canonical,
+    SUBTYPE_DIFF = uint8_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_uint8_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_uint8_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(uint8, uint8)
+RETURNS SETOF uint8
+AS '$libdir/uint128', 'generate_series_uint8'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint8_support;
+
+CREATE FUNCTION generate_series(uint8, uint8, uint8)
+RETURNS SETOF uint8
+AS '$libdir/uint128', 'generate_series_step_uint8'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint8_support;
+
+-- Agg ops block
+
+-- Transition function for accumulating uint16
+CREATE FUNCTION uint16_avg_accum(internal, uint16)
+RETURNS internal
+AS '$libdir/uint128', 'uint16_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating uint16
+CREATE FUNCTION uint16_avg_accum_inv(internal, uint16)
+RETURNS internal
+AS '$libdir/uint128', 'uint16_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(uint16) (
+    -- Transition function
+    SFUNC = uint16_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint16_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint16_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(uint16) (
+    -- Transition function
+    SFUNC = uint16_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = uint16_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = uint16_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint16_smaller(uint16, uint16)
+RETURNS uint16
+AS '$libdir/uint128', 'uint16_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(uint16) (
+    -- Transition function
+    SFUNC = uint16_smaller,         
+	STYPE = uint16,
+	COMBINEFUNC = uint16_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION uint16_larger(uint16, uint16)
+RETURNS uint16
+AS '$libdir/uint128', 'uint16_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(uint16) (
+    -- Transition function
+    SFUNC = uint16_larger,         
+	STYPE = uint16,
+	COMBINEFUNC = uint16_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE uint16range;
+
+CREATE OR REPLACE FUNCTION uint16_range_canonical(uint16range)
+RETURNS uint16range
+AS '$libdir/uint128', 'uint16_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION uint16_range_subdiff(uint16, uint16)
+RETURNS double precision
+AS '$libdir/uint128', 'uint16_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE uint16range AS RANGE (
+    SUBTYPE = uint16,
+    SUBTYPE_OPCLASS = uint16_ops,
+    CANONICAL = uint16_range_canonical,
+    SUBTYPE_DIFF = uint16_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_uint16_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_uint16_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(uint16, uint16)
+RETURNS SETOF uint16
+AS '$libdir/uint128', 'generate_series_uint16'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint16_support;
+
+CREATE FUNCTION generate_series(uint16, uint16, uint16)
+RETURNS SETOF uint16
+AS '$libdir/uint128', 'generate_series_step_uint16'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_uint16_support;
+
+-- Agg ops block
+
+-- Transition function for accumulating int1
+CREATE FUNCTION int1_avg_accum(internal, int1)
+RETURNS internal
+AS '$libdir/uint128', 'int1_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating int1
+CREATE FUNCTION int1_avg_accum_inv(internal, int1)
+RETURNS internal
+AS '$libdir/uint128', 'int1_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(int1) (
+    -- Transition function
+    SFUNC = int1_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = int1_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = int1_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(int1) (
+    -- Transition function
+    SFUNC = int1_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = int1_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = int1_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION int1_smaller(int1, int1)
+RETURNS int1
+AS '$libdir/uint128', 'int1_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(int1) (
+    -- Transition function
+    SFUNC = int1_smaller,         
+	STYPE = int1,
+	COMBINEFUNC = int1_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION int1_larger(int1, int1)
+RETURNS int1
+AS '$libdir/uint128', 'int1_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(int1) (
+    -- Transition function
+    SFUNC = int1_larger,         
+	STYPE = int1,
+	COMBINEFUNC = int1_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE int1range;
+
+CREATE OR REPLACE FUNCTION int1_range_canonical(int1range)
+RETURNS int1range
+AS '$libdir/uint128', 'int1_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION int1_range_subdiff(int1, int1)
+RETURNS double precision
+AS '$libdir/uint128', 'int1_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE int1range AS RANGE (
+    SUBTYPE = int1,
+    SUBTYPE_OPCLASS = int1_ops,
+    CANONICAL = int1_range_canonical,
+    SUBTYPE_DIFF = int1_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_int1_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_int1_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(int1, int1)
+RETURNS SETOF int1
+AS '$libdir/uint128', 'generate_series_int1'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_int1_support;
+
+CREATE FUNCTION generate_series(int1, int1, int1)
+RETURNS SETOF int1
+AS '$libdir/uint128', 'generate_series_step_int1'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_int1_support;
+
+-- Agg ops block
+
+-- Transition function for accumulating int16
+CREATE FUNCTION int16_avg_accum(internal, int16)
+RETURNS internal
+AS '$libdir/uint128', 'int16_avg_accum'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- Inverse transition function for accumulating int16
+CREATE FUNCTION int16_avg_accum_inv(internal, int16)
+RETURNS internal
+AS '$libdir/uint128', 'int16_avg_accum_inv'
+LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE sum(int16) (
+    -- Transition function
+    SFUNC = int16_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_sum,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = int16_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = int16_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_sum,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE AGGREGATE avg(int16) (
+    -- Transition function
+    SFUNC = int16_avg_accum,
+    -- Internal state type
+    STYPE = internal,
+    -- Internal state size
+    SSPACE = 128,
+    -- Final function to return the sum
+    FINALFUNC = numeric_avg,
+    -- Combine function for parallel aggregation
+    COMBINEFUNC = numeric_avg_combine,
+    -- Moving transition function
+    MSFUNC = int16_avg_accum,
+    -- Moving state type (same as STYPE)
+    MSTYPE = internal,
+    -- Moving inverse transition function
+    MINVFUNC = int16_avg_accum_inv,
+    -- Moving final function for windows
+    MFINALFUNC = numeric_avg,
+    -- Serialize function
+    SERIALFUNC = numeric_avg_serialize,
+    -- Deserialize function
+    DESERIALFUNC = numeric_avg_deserialize,
+    -- Aggregate is parallel safe
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION int16_smaller(int16, int16)
+RETURNS int16
+AS '$libdir/uint128', 'int16_smaller'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE min(int16) (
+    -- Transition function
+    SFUNC = int16_smaller,         
+	STYPE = int16,
+	COMBINEFUNC = int16_smaller,
+    SORTOP = <,
+    PARALLEL = SAFE
+);
+
+CREATE FUNCTION int16_larger(int16, int16)
+RETURNS int16
+AS '$libdir/uint128', 'int16_larger'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE AGGREGATE max(int16) (
+    -- Transition function
+    SFUNC = int16_larger,         
+	STYPE = int16,
+	COMBINEFUNC = int16_larger,
+    SORTOP = >,
+    PARALLEL = SAFE
+);
+
+
+
+-- Ranges block
+
+CREATE TYPE int16range;
+
+CREATE OR REPLACE FUNCTION int16_range_canonical(int16range)
+RETURNS int16range
+AS '$libdir/uint128', 'int16_range_canonical'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION int16_range_subdiff(int16, int16)
+RETURNS double precision
+AS '$libdir/uint128', 'int16_range_subdiff'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE TYPE int16range AS RANGE (
+    SUBTYPE = int16,
+    SUBTYPE_OPCLASS = int16_ops,
+    CANONICAL = int16_range_canonical,
+    SUBTYPE_DIFF = int16_range_subdiff
+);
+
+-- Generate series block
+
+CREATE FUNCTION generate_series_int16_support(internal)
+RETURNS internal
+AS '$libdir/uint128', 'generate_series_int16_support'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE FUNCTION generate_series(int16, int16)
+RETURNS SETOF int16
+AS '$libdir/uint128', 'generate_series_int16'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_int16_support;
+
+CREATE FUNCTION generate_series(int16, int16, int16)
+RETURNS SETOF int16
+AS '$libdir/uint128', 'generate_series_step_int16'
+LANGUAGE C IMMUTABLE PARALLEL SAFE STRICT SUPPORT generate_series_int16_support;
+-- Cast functions for uint1
+
+CREATE FUNCTION uint1_from_int1(int1) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int1';
+CREATE FUNCTION uint1_from_int2(int2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int2';
+CREATE FUNCTION uint1_from_int4(int4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int4';
+CREATE FUNCTION uint1_from_int8(int8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int8';
+CREATE FUNCTION uint1_from_int16(int16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_int16';
+CREATE FUNCTION uint1_from_uint2(uint2) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint2';
+CREATE FUNCTION uint1_from_uint4(uint4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint4';
+CREATE FUNCTION uint1_from_uint8(uint8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint8';
+CREATE FUNCTION uint1_from_uint16(uint16) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_uint16';
+CREATE FUNCTION uint1_from_numeric(numeric) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_numeric';
+CREATE FUNCTION uint1_from_float4(float4) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_float4';
+CREATE FUNCTION uint1_from_float8(float8) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_float8';
+CREATE FUNCTION uint1_from_json(json) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_json';
+CREATE FUNCTION uint1_from_jsonb(jsonb) RETURNS uint1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint1_from_jsonb';
+-- Casts for uint1
+
+CREATE CAST (int1 AS uint1) WITH FUNCTION uint1_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint1) WITH FUNCTION uint1_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint1) WITH FUNCTION uint1_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint1) WITH FUNCTION uint1_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint1) WITH FUNCTION uint1_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint2 AS uint1) WITH FUNCTION uint1_from_uint2(uint2) AS ASSIGNMENT;
+CREATE CAST (uint4 AS uint1) WITH FUNCTION uint1_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS uint1) WITH FUNCTION uint1_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS uint1) WITH FUNCTION uint1_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint1) WITH FUNCTION uint1_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint1) WITH FUNCTION uint1_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint1) WITH FUNCTION uint1_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint1) WITH FUNCTION uint1_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint1) WITH FUNCTION uint1_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Cast functions for uint2
+
+CREATE FUNCTION uint2_from_int1(int1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int1';
+CREATE FUNCTION uint2_from_int2(int2) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int2';
+CREATE FUNCTION uint2_from_int4(int4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int4';
+CREATE FUNCTION uint2_from_int8(int8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int8';
+CREATE FUNCTION uint2_from_int16(int16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_int16';
+CREATE FUNCTION uint2_from_uint1(uint1) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint1';
+CREATE FUNCTION uint2_from_uint4(uint4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint4';
+CREATE FUNCTION uint2_from_uint8(uint8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint8';
+CREATE FUNCTION uint2_from_uint16(uint16) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_uint16';
+CREATE FUNCTION uint2_from_numeric(numeric) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_numeric';
+CREATE FUNCTION uint2_from_float4(float4) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_float4';
+CREATE FUNCTION uint2_from_float8(float8) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_float8';
+CREATE FUNCTION uint2_from_json(json) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_json';
+CREATE FUNCTION uint2_from_jsonb(jsonb) RETURNS uint2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint2_from_jsonb';
+-- Casts for uint2
+
+CREATE CAST (int1 AS uint2) WITH FUNCTION uint2_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint2) WITH FUNCTION uint2_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint2) WITH FUNCTION uint2_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint2) WITH FUNCTION uint2_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint2) WITH FUNCTION uint2_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint2) WITH FUNCTION uint2_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint4 AS uint2) WITH FUNCTION uint2_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS uint2) WITH FUNCTION uint2_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS uint2) WITH FUNCTION uint2_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint2) WITH FUNCTION uint2_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint2) WITH FUNCTION uint2_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint2) WITH FUNCTION uint2_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint2) WITH FUNCTION uint2_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint2) WITH FUNCTION uint2_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Cast functions for uint4
+
+CREATE FUNCTION uint4_from_int1(int1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int1';
+CREATE FUNCTION uint4_from_int2(int2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int2';
+CREATE FUNCTION uint4_from_int4(int4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int4';
+CREATE FUNCTION uint4_from_int8(int8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int8';
+CREATE FUNCTION uint4_from_int16(int16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_int16';
+CREATE FUNCTION uint4_from_uint1(uint1) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint1';
+CREATE FUNCTION uint4_from_uint2(uint2) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint2';
+CREATE FUNCTION uint4_from_uint8(uint8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint8';
+CREATE FUNCTION uint4_from_uint16(uint16) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_uint16';
+CREATE FUNCTION uint4_from_numeric(numeric) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_numeric';
+CREATE FUNCTION uint4_from_float4(float4) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_float4';
+CREATE FUNCTION uint4_from_float8(float8) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_float8';
+CREATE FUNCTION uint4_from_json(json) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_json';
+CREATE FUNCTION uint4_from_jsonb(jsonb) RETURNS uint4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint4_from_jsonb';
+-- Casts for uint4
+
+CREATE CAST (int1 AS uint4) WITH FUNCTION uint4_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint4) WITH FUNCTION uint4_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint4) WITH FUNCTION uint4_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint4) WITH FUNCTION uint4_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint4) WITH FUNCTION uint4_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint4) WITH FUNCTION uint4_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS uint4) WITH FUNCTION uint4_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint8 AS uint4) WITH FUNCTION uint4_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS uint4) WITH FUNCTION uint4_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint4) WITH FUNCTION uint4_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint4) WITH FUNCTION uint4_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint4) WITH FUNCTION uint4_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint4) WITH FUNCTION uint4_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint4) WITH FUNCTION uint4_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Cast functions for uint8
+
+CREATE FUNCTION uint8_from_int1(int1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int1';
+CREATE FUNCTION uint8_from_int2(int2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int2';
+CREATE FUNCTION uint8_from_int4(int4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int4';
+CREATE FUNCTION uint8_from_int8(int8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int8';
+CREATE FUNCTION uint8_from_int16(int16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_int16';
+CREATE FUNCTION uint8_from_uint1(uint1) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint1';
+CREATE FUNCTION uint8_from_uint2(uint2) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint2';
+CREATE FUNCTION uint8_from_uint4(uint4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint4';
+CREATE FUNCTION uint8_from_uint16(uint16) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_uint16';
+CREATE FUNCTION uint8_from_float4(float4) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_float4';
+CREATE FUNCTION uint8_from_float8(float8) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_float8';
+CREATE FUNCTION uint8_from_json(json) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_json';
+CREATE FUNCTION uint8_from_jsonb(jsonb) RETURNS uint8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint8_from_jsonb';
+-- Casts for uint8
+
+CREATE CAST (int1 AS uint8) WITH FUNCTION uint8_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint8) WITH FUNCTION uint8_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint8) WITH FUNCTION uint8_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint8) WITH FUNCTION uint8_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint8) WITH FUNCTION uint8_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint8) WITH FUNCTION uint8_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS uint8) WITH FUNCTION uint8_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS uint8) WITH FUNCTION uint8_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint16 AS uint8) WITH FUNCTION uint8_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (float4 AS uint8) WITH FUNCTION uint8_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint8) WITH FUNCTION uint8_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint8) WITH FUNCTION uint8_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint8) WITH FUNCTION uint8_from_jsonb(jsonb) AS ASSIGNMENT;
+CREATE CAST (numeric AS uint8) WITH INOUT AS ASSIGNMENT;
+
+-- Cast functions for uint16
+
+CREATE FUNCTION uint16_from_int1(int1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int1';
+CREATE FUNCTION uint16_from_int2(int2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int2';
+CREATE FUNCTION uint16_from_int4(int4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int4';
+CREATE FUNCTION uint16_from_int8(int8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int8';
+CREATE FUNCTION uint16_from_int16(int16) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_int16';
+CREATE FUNCTION uint16_from_uint1(uint1) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint1';
+CREATE FUNCTION uint16_from_uint2(uint2) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint2';
+CREATE FUNCTION uint16_from_uint4(uint4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint4';
+CREATE FUNCTION uint16_from_uint8(uint8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uint8';
+CREATE FUNCTION uint16_from_float4(float4) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_float4';
+CREATE FUNCTION uint16_from_float8(float8) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_float8';
+CREATE FUNCTION uint16_from_json(json) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_json';
+CREATE FUNCTION uint16_from_jsonb(jsonb) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_jsonb';
+CREATE FUNCTION uint16_from_uuid(uuid) RETURNS uint16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uint16_from_uuid';
+-- Casts for uint16
+
+CREATE CAST (int1 AS uint16) WITH FUNCTION uint16_from_int1(int1) AS ASSIGNMENT;
+CREATE CAST (int2 AS uint16) WITH FUNCTION uint16_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS uint16) WITH FUNCTION uint16_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS uint16) WITH FUNCTION uint16_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS uint16) WITH FUNCTION uint16_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (uint1 AS uint16) WITH FUNCTION uint16_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS uint16) WITH FUNCTION uint16_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS uint16) WITH FUNCTION uint16_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS uint16) WITH FUNCTION uint16_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (float4 AS uint16) WITH FUNCTION uint16_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS uint16) WITH FUNCTION uint16_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS uint16) WITH FUNCTION uint16_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS uint16) WITH FUNCTION uint16_from_jsonb(jsonb) AS ASSIGNMENT;
+CREATE CAST (uuid AS uint16) WITH FUNCTION uint16_from_uuid(uuid) AS IMPLICIT;
+CREATE CAST (numeric AS uint16) WITH INOUT AS ASSIGNMENT;
+
+-- Cast functions for int1
+
+CREATE FUNCTION int1_from_uint1(uint1) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint1';
+CREATE FUNCTION int1_from_uint2(uint2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint2';
+CREATE FUNCTION int1_from_uint4(uint4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint4';
+CREATE FUNCTION int1_from_uint8(uint8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint8';
+CREATE FUNCTION int1_from_uint16(uint16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_uint16';
+CREATE FUNCTION int1_from_int2(int2) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int2';
+CREATE FUNCTION int1_from_int4(int4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int4';
+CREATE FUNCTION int1_from_int8(int8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int8';
+CREATE FUNCTION int1_from_int16(int16) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_int16';
+CREATE FUNCTION int1_from_numeric(numeric) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_numeric';
+CREATE FUNCTION int1_from_float4(float4) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_float4';
+CREATE FUNCTION int1_from_float8(float8) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_float8';
+CREATE FUNCTION int1_from_json(json) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_json';
+CREATE FUNCTION int1_from_jsonb(jsonb) RETURNS int1
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int1_from_jsonb';
+-- Casts for int1
+
+CREATE CAST (uint1 AS int1) WITH FUNCTION int1_from_uint1(uint1) AS ASSIGNMENT;
+CREATE CAST (uint2 AS int1) WITH FUNCTION int1_from_uint2(uint2) AS ASSIGNMENT;
+CREATE CAST (uint4 AS int1) WITH FUNCTION int1_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS int1) WITH FUNCTION int1_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int1) WITH FUNCTION int1_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int2 AS int1) WITH FUNCTION int1_from_int2(int2) AS ASSIGNMENT;
+CREATE CAST (int4 AS int1) WITH FUNCTION int1_from_int4(int4) AS ASSIGNMENT;
+CREATE CAST (int8 AS int1) WITH FUNCTION int1_from_int8(int8) AS ASSIGNMENT;
+CREATE CAST (int16 AS int1) WITH FUNCTION int1_from_int16(int16) AS ASSIGNMENT;
+CREATE CAST (numeric AS int1) WITH FUNCTION int1_from_numeric(numeric) AS ASSIGNMENT;
+CREATE CAST (float4 AS int1) WITH FUNCTION int1_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS int1) WITH FUNCTION int1_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS int1) WITH FUNCTION int1_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS int1) WITH FUNCTION int1_from_jsonb(jsonb) AS ASSIGNMENT;
+
+-- Cast functions for int2
+
+CREATE FUNCTION int2_from_uint1(uint1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint1';
+CREATE FUNCTION int2_from_uint2(uint2) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint2';
+CREATE FUNCTION int2_from_uint4(uint4) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint4';
+CREATE FUNCTION int2_from_uint8(uint8) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint8';
+CREATE FUNCTION int2_from_uint16(uint16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_uint16';
+CREATE FUNCTION int2_from_int1(int1) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_int1';
+CREATE FUNCTION int2_from_int16(int16) RETURNS int2
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int2_from_int16';
+-- Casts for int2
+
+CREATE CAST (uint1 AS int2) WITH FUNCTION int2_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int2) WITH FUNCTION int2_from_uint2(uint2) AS ASSIGNMENT;
+CREATE CAST (uint4 AS int2) WITH FUNCTION int2_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS int2) WITH FUNCTION int2_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int2) WITH FUNCTION int2_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int2) WITH FUNCTION int2_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS int2) WITH FUNCTION int2_from_int16(int16) AS ASSIGNMENT;
+
+-- Cast functions for int4
+
+CREATE FUNCTION int4_from_uint1(uint1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint1';
+CREATE FUNCTION int4_from_uint2(uint2) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint2';
+CREATE FUNCTION int4_from_uint4(uint4) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint4';
+CREATE FUNCTION int4_from_uint8(uint8) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint8';
+CREATE FUNCTION int4_from_uint16(uint16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_uint16';
+CREATE FUNCTION int4_from_int1(int1) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_int1';
+CREATE FUNCTION int4_from_int16(int16) RETURNS int4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int4_from_int16';
+-- Casts for int4
+
+CREATE CAST (uint1 AS int4) WITH FUNCTION int4_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int4) WITH FUNCTION int4_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS int4) WITH FUNCTION int4_from_uint4(uint4) AS ASSIGNMENT;
+CREATE CAST (uint8 AS int4) WITH FUNCTION int4_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int4) WITH FUNCTION int4_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int4) WITH FUNCTION int4_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS int4) WITH FUNCTION int4_from_int16(int16) AS ASSIGNMENT;
+
+-- Cast functions for int8
+
+CREATE FUNCTION int8_from_uint1(uint1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint1';
+CREATE FUNCTION int8_from_uint2(uint2) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint2';
+CREATE FUNCTION int8_from_uint4(uint4) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint4';
+CREATE FUNCTION int8_from_uint8(uint8) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint8';
+CREATE FUNCTION int8_from_uint16(uint16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_uint16';
+CREATE FUNCTION int8_from_int1(int1) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_int1';
+CREATE FUNCTION int8_from_int16(int16) RETURNS int8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int8_from_int16';
+-- Casts for int8
+
+CREATE CAST (uint1 AS int8) WITH FUNCTION int8_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int8) WITH FUNCTION int8_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS int8) WITH FUNCTION int8_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS int8) WITH FUNCTION int8_from_uint8(uint8) AS ASSIGNMENT;
+CREATE CAST (uint16 AS int8) WITH FUNCTION int8_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int8) WITH FUNCTION int8_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS int8) WITH FUNCTION int8_from_int16(int16) AS ASSIGNMENT;
+
+-- Cast functions for int16
+
+CREATE FUNCTION int16_from_uint1(uint1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint1';
+CREATE FUNCTION int16_from_uint2(uint2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint2';
+CREATE FUNCTION int16_from_uint4(uint4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint4';
+CREATE FUNCTION int16_from_uint8(uint8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint8';
+CREATE FUNCTION int16_from_uint16(uint16) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_uint16';
+CREATE FUNCTION int16_from_int1(int1) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int1';
+CREATE FUNCTION int16_from_int2(int2) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int2';
+CREATE FUNCTION int16_from_int4(int4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int4';
+CREATE FUNCTION int16_from_int8(int8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_int8';
+CREATE FUNCTION int16_from_float4(float4) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_float4';
+CREATE FUNCTION int16_from_float8(float8) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_float8';
+CREATE FUNCTION int16_from_json(json) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_json';
+CREATE FUNCTION int16_from_jsonb(jsonb) RETURNS int16
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LANGUAGE C
+    AS '$libdir/uint128', 'int16_from_jsonb';
+-- Casts for int16
+
+CREATE CAST (uint1 AS int16) WITH FUNCTION int16_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS int16) WITH FUNCTION int16_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS int16) WITH FUNCTION int16_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS int16) WITH FUNCTION int16_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS int16) WITH FUNCTION int16_from_uint16(uint16) AS ASSIGNMENT;
+CREATE CAST (int1 AS int16) WITH FUNCTION int16_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int2 AS int16) WITH FUNCTION int16_from_int2(int2) AS IMPLICIT;
+CREATE CAST (int4 AS int16) WITH FUNCTION int16_from_int4(int4) AS IMPLICIT;
+CREATE CAST (int8 AS int16) WITH FUNCTION int16_from_int8(int8) AS IMPLICIT;
+CREATE CAST (float4 AS int16) WITH FUNCTION int16_from_float4(float4) AS ASSIGNMENT;
+CREATE CAST (float8 AS int16) WITH FUNCTION int16_from_float8(float8) AS ASSIGNMENT;
+CREATE CAST (json AS int16) WITH FUNCTION int16_from_json(json) AS ASSIGNMENT;
+CREATE CAST (jsonb AS int16) WITH FUNCTION int16_from_jsonb(jsonb) AS ASSIGNMENT;
+CREATE CAST (numeric AS int16) WITH INOUT AS ASSIGNMENT;
+
+-- Cast functions for numeric
+
+CREATE FUNCTION numeric_from_uint1(uint1) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint1';
+CREATE FUNCTION numeric_from_uint2(uint2) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint2';
+CREATE FUNCTION numeric_from_uint4(uint4) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_uint4';
+CREATE FUNCTION numeric_from_int1(int1) RETURNS numeric
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'numeric_from_int1';
+-- Casts for numeric
+
+CREATE CAST (uint1 AS numeric) WITH FUNCTION numeric_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS numeric) WITH FUNCTION numeric_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS numeric) WITH FUNCTION numeric_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (int1 AS numeric) WITH FUNCTION numeric_from_int1(int1) AS IMPLICIT;
+CREATE CAST (uint8 AS numeric) WITH INOUT AS IMPLICIT;
+CREATE CAST (uint16 AS numeric) WITH INOUT AS IMPLICIT;
+CREATE CAST (int16 AS numeric) WITH INOUT AS IMPLICIT;
+
+-- Cast functions for float4
+
+CREATE FUNCTION float4_from_uint1(uint1) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint1';
+CREATE FUNCTION float4_from_uint2(uint2) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint2';
+CREATE FUNCTION float4_from_uint4(uint4) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint4';
+CREATE FUNCTION float4_from_uint8(uint8) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint8';
+CREATE FUNCTION float4_from_uint16(uint16) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_uint16';
+CREATE FUNCTION float4_from_int1(int1) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_int1';
+CREATE FUNCTION float4_from_int16(int16) RETURNS float4
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float4_from_int16';
+-- Casts for float4
+
+CREATE CAST (uint1 AS float4) WITH FUNCTION float4_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS float4) WITH FUNCTION float4_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS float4) WITH FUNCTION float4_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS float4) WITH FUNCTION float4_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS float4) WITH FUNCTION float4_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS float4) WITH FUNCTION float4_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS float4) WITH FUNCTION float4_from_int16(int16) AS IMPLICIT;
+
+-- Cast functions for float8
+
+CREATE FUNCTION float8_from_uint1(uint1) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint1';
+CREATE FUNCTION float8_from_uint2(uint2) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint2';
+CREATE FUNCTION float8_from_uint4(uint4) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint4';
+CREATE FUNCTION float8_from_uint8(uint8) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint8';
+CREATE FUNCTION float8_from_uint16(uint16) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_uint16';
+CREATE FUNCTION float8_from_int1(int1) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_int1';
+CREATE FUNCTION float8_from_int16(int16) RETURNS float8
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'float8_from_int16';
+-- Casts for float8
+
+CREATE CAST (uint1 AS float8) WITH FUNCTION float8_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS float8) WITH FUNCTION float8_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS float8) WITH FUNCTION float8_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS float8) WITH FUNCTION float8_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS float8) WITH FUNCTION float8_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS float8) WITH FUNCTION float8_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS float8) WITH FUNCTION float8_from_int16(int16) AS IMPLICIT;
+
+-- Cast functions for json
+
+CREATE FUNCTION json_from_uint1(uint1) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint1';
+CREATE FUNCTION json_from_uint2(uint2) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint2';
+CREATE FUNCTION json_from_uint4(uint4) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint4';
+CREATE FUNCTION json_from_uint8(uint8) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint8';
+CREATE FUNCTION json_from_uint16(uint16) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_uint16';
+CREATE FUNCTION json_from_int1(int1) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_int1';
+CREATE FUNCTION json_from_int16(int16) RETURNS json
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'json_from_int16';
+-- Casts for json
+
+CREATE CAST (uint1 AS json) WITH FUNCTION json_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS json) WITH FUNCTION json_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS json) WITH FUNCTION json_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS json) WITH FUNCTION json_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS json) WITH FUNCTION json_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS json) WITH FUNCTION json_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS json) WITH FUNCTION json_from_int16(int16) AS IMPLICIT;
+
+-- Cast functions for jsonb
+
+CREATE FUNCTION jsonb_from_uint1(uint1) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint1';
+CREATE FUNCTION jsonb_from_uint2(uint2) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint2';
+CREATE FUNCTION jsonb_from_uint4(uint4) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint4';
+CREATE FUNCTION jsonb_from_uint8(uint8) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint8';
+CREATE FUNCTION jsonb_from_uint16(uint16) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_uint16';
+CREATE FUNCTION jsonb_from_int1(int1) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_int1';
+CREATE FUNCTION jsonb_from_int16(int16) RETURNS jsonb
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'jsonb_from_int16';
+-- Casts for jsonb
+
+CREATE CAST (uint1 AS jsonb) WITH FUNCTION jsonb_from_uint1(uint1) AS IMPLICIT;
+CREATE CAST (uint2 AS jsonb) WITH FUNCTION jsonb_from_uint2(uint2) AS IMPLICIT;
+CREATE CAST (uint4 AS jsonb) WITH FUNCTION jsonb_from_uint4(uint4) AS IMPLICIT;
+CREATE CAST (uint8 AS jsonb) WITH FUNCTION jsonb_from_uint8(uint8) AS IMPLICIT;
+CREATE CAST (uint16 AS jsonb) WITH FUNCTION jsonb_from_uint16(uint16) AS IMPLICIT;
+CREATE CAST (int1 AS jsonb) WITH FUNCTION jsonb_from_int1(int1) AS IMPLICIT;
+CREATE CAST (int16 AS jsonb) WITH FUNCTION jsonb_from_int16(int16) AS IMPLICIT;
+
+-- Cast functions for uuid
+
+CREATE FUNCTION uuid_from_uint16(uint16) RETURNS uuid
+    IMMUTABLE
+    PARALLEL SAFE
+    STRICT
+    LEAKPROOF
+    LANGUAGE C
+    AS '$libdir/uint128', 'uuid_from_uint16';
+-- Casts for uuid
+
+CREATE CAST (uint16 AS uuid) WITH FUNCTION uuid_from_uint16(uint16) AS IMPLICIT;
+

--- a/uint128.c
+++ b/uint128.c
@@ -17,7 +17,7 @@ PG_FUNCTION_INFO_V1(uint16_cmp);
 PG_FUNCTION_INFO_V1(uint16_hash);
 
 PG_FUNCTION_INFO_V1(uint16_from_uuid);
-PG_FUNCTION_INFO_V1(uint16_to_uuid);
+PG_FUNCTION_INFO_V1(uuid_from_uint16);
 
 // Serialization ops
 
@@ -144,7 +144,7 @@ Datum uint16_from_uuid(PG_FUNCTION_ARGS)
     PG_RETURN_UINT128_P(result);
 }
 
-Datum uint16_to_uuid(PG_FUNCTION_ARGS)
+Datum uuid_from_uint16(PG_FUNCTION_ARGS)
 {
     uint128   *uint = PG_GETARG_UINT128_P(0);
     pg_uuid_t *uuid = palloc(sizeof(pg_uuid_t));

--- a/uint128.control
+++ b/uint128.control
@@ -1,4 +1,4 @@
 comment = 'Native uint128 type'
-default_version = '1.1.1'
+default_version = '1.2.0'
 relocatable = true
 module_pathname = '$libdir/uint128'

--- a/uint_utils.h
+++ b/uint_utils.h
@@ -44,6 +44,53 @@ static inline uint128* AllocUint128(uint128 initial)
 #define PG_RETURN_UINT8(x)  return UInt8GetDatum(x)
 #endif
 
+
+/*
+ * Macros for range-checking float values before converting to integer.
+ * We must be careful here that the boundary values are expressed exactly
+ * in the float domain.  PG_INTnn_MIN is an exact power of 2, so it will
+ * be represented exactly; but PG_INTnn_MAX isn't, and might get rounded
+ * off, so avoid using that.
+ * The input must be rounded to an integer beforehand, typically with rint(),
+ * else we might draw the wrong conclusion about close-to-the-limit values.
+ * These macros will do the right thing for Inf, but not necessarily for NaN,
+ * so check isnan(num) first if that's a possibility.
+ *
+ * Src: https://github.com/postgres/postgres/blob/9016fa7e3bcde8ae4c3d63c707143af147486a10/src/include/c.h#L1054
+ *
+ * Note: For unsigned integers we use the next power of two, i.e. uint8 max 255 becomes 256
+ */
+
+#define FLOAT4_FITS_IN_UINT8(num) \
+	((num) >= (float4) 0 && (num) < (256.0f))
+
+#define FLOAT4_FITS_IN_UINT16(num) \
+	((num) >= (float4) 0 && (num) < (65536.0f))
+
+#define FLOAT4_FITS_IN_UINT32(num) \
+	((num) >= (float4) 0 && (num) < (4294967296.0f))
+
+#define FLOAT4_FITS_IN_UINT64(num) \
+	((num) >= (float4) 0 && (num) < (18446744073709551616.0f))
+
+#define FLOAT4_FITS_IN_UINT128(num) \
+	((num) >= (float4) 0 && (num) < (340282366920938463463374607431768211456.0f))
+
+#define FLOAT8_FITS_IN_UINT8(num) \
+	((num) >= (float8) 0 && (num) < (256.0))
+
+#define FLOAT8_FITS_IN_UINT16(num) \
+	((num) >= (float8) 0 && (num) < (65536.0))
+
+#define FLOAT8_FITS_IN_UINT32(num) \
+	((num) >= (float8) 0 && (num) < (4294967296.0))
+
+#define FLOAT8_FITS_IN_UINT64(num) \
+	((num) >= (float8) 0 && (num) < (18446744073709551616.0))
+
+#define FLOAT8_FITS_IN_UINT128(num) \
+	((num) >= (float8) 0 && (num) < (340282366920938463463374607431768211456.0))
+
 #define DIVISION_BY_ZERO_ERR \
     ereport(ERROR, \
         ( \


### PR DESCRIPTION
* Replaced "to" cast functions with unified "from" notation
* Marked cast functions as PARALLEL SAFE to allow parallel queries
* Cast functions that cannot error marked as LEAKPROOF (may improve performance when using Postgres RLS, see https://dba.stackexchange.com/a/210391/160775)
* Correctly defined IMPLICIT vs ASSIGNMENT casts:
  * IMPLICIT for error-free casts
  * ASSIGNMENT for casts that may error
* Native casts for/from float4/float8 types